### PR TITLE
Zig zag update

### DIFF
--- a/project/OsEngine/Language/JournalLocal.cs
+++ b/project/OsEngine/Language/JournalLocal.cs
@@ -48,7 +48,7 @@ namespace OsEngine.Language
             "Ru:Удалить все_");
 
         public string PositionMenuItem11 => OsLocalization.ConvertToLocString(
-            "Eng:Save in fail_" +
+            "Eng:Save to file_" +
             "Ru:Сохранить в файл_");
 
         public string PositionMenuItem12 => OsLocalization.ConvertToLocString(

--- a/project/OsEngine/bin/Debug/Custom/Indicators/Scripts/ZigZag.cs
+++ b/project/OsEngine/bin/Debug/Custom/Indicators/Scripts/ZigZag.cs
@@ -12,6 +12,8 @@ namespace CustomIndicators.Scripts
         private IndicatorParameterInt _period;
         private IndicatorDataSeries _seriesZigZag;
         private IndicatorDataSeries _seriesToLine;
+        private IndicatorDataSeries _seriesZigZagHighs;
+        private IndicatorDataSeries _seriesZigZagLows;
 
         public override void OnStateChange(IndicatorState state)
         {
@@ -21,6 +23,13 @@ namespace CustomIndicators.Scripts
 
             _seriesToLine = CreateSeries("ZigZagLine", Color.CornflowerBlue, IndicatorChartPaintType.Point, true);
             _seriesToLine.CanReBuildHistoricalValues = true;
+
+            _seriesZigZagHighs = CreateSeries("_seriesZigZagHighs", Color.GreenYellow, IndicatorChartPaintType.Point, false);
+            _seriesZigZagHighs.CanReBuildHistoricalValues = true;
+
+            _seriesZigZagLows = CreateSeries("_seriesZigZagLows", Color.Red, IndicatorChartPaintType.Point, false);
+            _seriesZigZagLows.CanReBuildHistoricalValues = true;
+
         }
 
         private decimal currentZigZagHigh = 0;
@@ -86,19 +95,29 @@ namespace CustomIndicators.Scripts
             if (addHigh || addLow || updateHigh || updateLow)
             {
                 if (updateHigh && lastSwingIndex >= 0)
+                {
                     _seriesZigZag.Values[lastSwingIndex] = 0; // тут в оригинале double.NaN
+                    _seriesZigZagHighs.Values[lastSwingIndex] = 0;
+                }
                 else if (updateLow && lastSwingIndex >= 0)
+                {
                     _seriesZigZag.Values[lastSwingIndex] = 0; // тут в оригинале double.NaN
+                    _seriesZigZagLows.Values[lastSwingIndex] = 0;
+                }
 
                 if (addHigh || updateHigh)
                 {
                     currentZigZagHigh = saveValue;
                     _seriesZigZag.Values[index] = currentZigZagHigh;
+                    _seriesZigZagHighs.Values[index] = currentZigZagHigh;
+
                 }
                 else if (addLow || updateLow)
                 {
                     currentZigZagLow = saveValue;
                     _seriesZigZag.Values[index] = currentZigZagLow;
+                    _seriesZigZagLows.Values[index] = currentZigZagLow;
+
                 }
 
                 lastSwingIndex = index;


### PR DESCRIPTION
1. Добавил отдельные серии для High/Low в индикатор ZigZag. 
Пример использования: Можно будет обращаться к конкретным экстремумам, и например, определять тренд по повышающимся максимумам. 
`List<decimal> zzHighs = _zz.DataSeries[2].Values.FindAll(i => i > 0);`
2. исправил опечатку