### PR TITLE
QuikLua Fix. download historical data

### DIFF
--- a/project/OsEngine/Entity/CandleManager.cs
+++ b/project/OsEngine/Entity/CandleManager.cs
@@ -324,9 +324,11 @@ namespace OsEngine.Entity
                             if (series.CandleCreateMethodType != CandleCreateMethodType.Simple || 
                                 series.TimeFrameSpan.TotalMinutes < 1)
                             {
-                                List<Trade> allTrades = _server.GetAllTradesToSecurity(series.Security);
-
-                                series.PreLoad(allTrades);
+                                List<Trade> allTrades = luaServ.GetQuikLuaTickHistory(series.Security.Name);
+                                if (allTrades != null && allTrades.Count != 0)
+                                {
+                                    series.PreLoad(allTrades);
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
1. **проблема**. для таймфреймов, которые строятся из тиковых данных (Tick/Volume/Renko), не работало скачивание исторических данных, хотя Quik обычно предоставляет данные с 19.00 вчерашнего дня.  Индикаторы не строятся. 
`_server.GetAllTradesToSecurity(series.Security)` подгружает только сохраненные данные из прошлых сессий. 
**решение**. добавил новый метод
**плюсы**. теперь работает :)
**минусы**. за день где то 600к тиков  на SiU0, из-за этого может скачиваться около 2-3 минут, но т.к это делается только 1 раз, при старте бота, то жить можно.

2. добавил H2/H4/D1 для исторических свечек, ибо была заглушка `if (timeSpan.TotalMinutes > 60 {return null;}`