### PR TITLE
fix trades drawing on chart for Tick TF

### DIFF
--- a/project/OsEngine/Charts/CandleChart/ChartCandleMaster.cs
+++ b/project/OsEngine/Charts/CandleChart/ChartCandleMaster.cs
@@ -1393,7 +1393,8 @@ namespace OsEngine.Charts.CandleChart
         {
             if (_securityOnThisChart == security &&
                 _timeFrameSecurity == timeFrameBuilder.TimeFrame &&
-                serverType == _serverType)
+                serverType == _serverType &&
+                _candleCreateMethodTypeOnThisChart == timeFrameBuilder.CandleCreateMethodType)
             {
                 return;
             }
@@ -1401,7 +1402,14 @@ namespace OsEngine.Charts.CandleChart
             if (ChartCandle != null)
             {
                 ChartCandle.ClearDataPointsAndSizeValue();
-                ChartCandle.SetNewTimeFrame(timeFrameBuilder.TimeFrameTimeSpan, timeFrameBuilder.TimeFrame);
+                if (timeFrameBuilder.CandleCreateMethodType != CandleCreateMethodType.Simple)
+                {
+                    ChartCandle.SetNewTimeFrame(TimeSpan.FromSeconds(1), timeFrameBuilder.TimeFrame);
+                }
+                else
+                {
+                    ChartCandle.SetNewTimeFrame(timeFrameBuilder.TimeFrameTimeSpan, timeFrameBuilder.TimeFrame);
+                }
             }
 
             string lastSecurity = _securityOnThisChart;
@@ -1410,6 +1418,7 @@ namespace OsEngine.Charts.CandleChart
             _securityOnThisChart = security;
             _timeFrameSecurity = timeFrameBuilder.TimeFrame;
             _serverType = serverType;
+            _candleCreateMethodTypeOnThisChart = timeFrameBuilder.CandleCreateMethodType;
 
             Clear();
             PaintLabelOnSlavePanel();
@@ -1435,6 +1444,12 @@ namespace OsEngine.Charts.CandleChart
         /// таймфрейм бумаги этого чарта
         /// </summary>
         private TimeFrame _timeFrameSecurity;
+
+        /// <summary>
+        /// candles built method
+        /// метод построения свечей на чарте
+        /// </summary>
+        private CandleCreateMethodType _candleCreateMethodTypeOnThisChart;
 
         private System.Windows.Controls.Label _label;
 


### PR DESCRIPTION
**Проблема**
Сделки отображаются некорректно для свечек построенных  из тиковых данных (tick/volume...)
![bad](https://user-images.githubusercontent.com/8736349/90894427-42fc8b00-e3c9-11ea-9b23-e9c5d0cd0cbf.png)

**где** 
если я правильно понял, чтобы выбрать, на какой свече рисовать сделку, ищем ее индекс `WinformsChartPainter.GetTimeIndex`, потом `MagicSearch`, который использует `_timeFrameSpan` для приращения.

**почему** 
`_timeFrameSpan `обновляется через `ChartCandleMaster.SetNewSecurity`, который всегда `return;` делает, даже не заходя, ибо `TimeFrame & Security для !=Simple` чартов всегда одинаковые (из кеша?). Таким образом _timeFrameSpan=1minute всегда. соответственно у нас погрешность до 1 минуты, что на маленьких ТФ критично (10-20 свечек пропускаем)

**как** 
добавил проверку на тип чарта и передаю _timeFrameSpan = 1sec для !=simple.

**PS.** Возможно, у Вас есть идеи как сделать лучше. но данный вариант работает.

![good](https://user-images.githubusercontent.com/8736349/90895309-a20ecf80-e3ca-11ea-8556-60af0d654d26.png)
