### PR TITLE
fix. saving trade string to file when Id is null

### DIFF
--- a/project/OsEngine/Entity/Trade.cs
+++ b/project/OsEngine/Entity/Trade.cs
@@ -110,8 +110,13 @@ namespace OsEngine.Entity
             result += Price.ToString(CultureInfo.InvariantCulture) + ",";
             result += Volume.ToString(CultureInfo.InvariantCulture) + ",";
             result += Side + ",";
-            result += MicroSeconds + ",";
-            result += Id;
+            result += MicroSeconds;
+
+            if (Id != null)
+            {
+                result += ",";
+                result += Id;
+            }
 
             if (Bid != 0 && Ask != 0 &&
                 BidsVolume != 0 && AsksVolume != 0)


### PR DESCRIPTION
По Вашему совету, попробовал тестировать, используя построение секундных графиков из тиков.

Пример, трейды скаченные через OsData с Finam, не имеют Id, 
изза этого в итоговый файл записывается строка `20200615,100000,71068.000000000,1,Buy,0,` с лишней запятой в конце, которую Тестер хочет считать как шестой символ ака iqfeed.

Ps. так же медленно, но есть плюс - трейды находятся внутри свечи, которые можно использовать. Спасибо!