### PR TITLE
add signal type to positions in journal

### DIFF
--- a/project/OsEngine/Entity/DataGridFactory.cs
+++ b/project/OsEngine/Entity/DataGridFactory.cs
@@ -243,6 +243,21 @@ namespace OsEngine.Entity
 
             newGrid.Columns.Add(colum12);
 
+            DataGridViewColumn colum13 = new DataGridViewColumn();
+            colum13.CellTemplate = cell0;
+            colum13.HeaderText = OsLocalization.Entity.PositionColumn18;
+            colum13.ReadOnly = true;
+            colum13.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+
+            newGrid.Columns.Add(colum13);
+
+            DataGridViewColumn colum14 = new DataGridViewColumn();
+            colum14.CellTemplate = cell0;
+            colum14.HeaderText = OsLocalization.Entity.PositionColumn19;
+            colum14.ReadOnly = true;
+            colum14.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+
+            newGrid.Columns.Add(colum14);
 
             return newGrid;
         }

--- a/project/OsEngine/Entity/PositionUi.xaml.cs
+++ b/project/OsEngine/Entity/PositionUi.xaml.cs
@@ -140,6 +140,12 @@ namespace OsEngine.Entity
             nRow.Cells.Add(new DataGridViewTextBoxCell());
             nRow.Cells[16].Value = position.ProfitOrderPrice.ToStringWithNoEndZero();
 
+            nRow.Cells.Add(new DataGridViewTextBoxCell());
+            nRow.Cells[17].Value = position.SignalTypeOpen;
+
+            nRow.Cells.Add(new DataGridViewTextBoxCell());
+            nRow.Cells[18].Value = position.SignalTypeClose;
+
             return nRow;
         }
         // Orders

--- a/project/OsEngine/Journal/Internal/PositionController.cs
+++ b/project/OsEngine/Journal/Internal/PositionController.cs
@@ -1318,6 +1318,12 @@ namespace OsEngine.Journal.Internal
                 nRow.Cells.Add(new DataGridViewTextBoxCell());
                 nRow.Cells[16].Value = position.ProfitOrderPrice.ToStringWithNoEndZero();
 
+                nRow.Cells.Add(new DataGridViewTextBoxCell());
+                nRow.Cells[17].Value = position.SignalTypeOpen;
+
+                nRow.Cells.Add(new DataGridViewTextBoxCell());
+                nRow.Cells[18].Value = position.SignalTypeClose;
+
                 return nRow;
             }
             catch (Exception error)

--- a/project/OsEngine/Journal/JournalUi.xaml.cs
+++ b/project/OsEngine/Journal/JournalUi.xaml.cs
@@ -1568,6 +1568,12 @@ namespace OsEngine.Journal
                 nRow.Cells.Add(new DataGridViewTextBoxCell());
                 nRow.Cells[16].Value = position.ProfitOrderPrice.ToStringWithNoEndZero();
 
+                nRow.Cells.Add(new DataGridViewTextBoxCell());
+                nRow.Cells[17].Value = position.SignalTypeOpen;
+
+                nRow.Cells.Add(new DataGridViewTextBoxCell());
+                nRow.Cells[18].Value = position.SignalTypeClose;
+
                 return nRow;
             }
             catch (Exception error)
@@ -1821,7 +1827,9 @@ namespace OsEngine.Journal
                 workSheet.Append(OsLocalization.Entity.PositionColumn14);
                 workSheet.Append(OsLocalization.Entity.PositionColumn15);
                 workSheet.Append(OsLocalization.Entity.PositionColumn16);
-                workSheet.Append(OsLocalization.Entity.PositionColumn17 +"\r\n");
+                workSheet.Append(OsLocalization.Entity.PositionColumn17);
+                workSheet.Append(OsLocalization.Entity.PositionColumn18);
+                workSheet.Append(OsLocalization.Entity.PositionColumn19 + "\r\n");
 
                 for (int i = 0; i < _closePositionGrid.Rows.Count; i++)
                 {
@@ -1842,7 +1850,9 @@ namespace OsEngine.Journal
                     workSheet.Append(_closePositionGrid.Rows[i].Cells[13].Value + ";");
                     workSheet.Append(_closePositionGrid.Rows[i].Cells[14].Value + ";");
                     workSheet.Append(_closePositionGrid.Rows[i].Cells[15].Value + ";");
-                    workSheet.Append(_closePositionGrid.Rows[i].Cells[16].Value + "\r\n");
+                    workSheet.Append(_closePositionGrid.Rows[i].Cells[16].Value + ";");
+                    workSheet.Append(_closePositionGrid.Rows[i].Cells[17].Value + ";");
+                    workSheet.Append(_closePositionGrid.Rows[i].Cells[18].Value + "\r\n");
                 }
 
                 string fileName = myDialog.FileName;

--- a/project/OsEngine/Language/EntityLocal.cs
+++ b/project/OsEngine/Language/EntityLocal.cs
@@ -127,6 +127,14 @@ namespace OsEngine.Language
             "Eng:Profit Price_" +
             "Ru:Профит цена_");
 
+        public string PositionColumn18 => OsLocalization.ConvertToLocString(
+            "Eng:Signal Type Open_" +
+            "Ru:Тип Сигнала на Открытие_");
+
+        public string PositionColumn19 => OsLocalization.ConvertToLocString(
+            "Eng:Signal Type Close_" +
+            "Ru:Тип Сигнала на Закрытие_");
+
         public string OrderColumn1 => OsLocalization.ConvertToLocString(
             "Eng:ID_" +
             "Ru:ID_");

--- a/project/OsEngine/OsTrader/GlobalPosition.cs
+++ b/project/OsEngine/OsTrader/GlobalPosition.cs
@@ -344,6 +344,12 @@ namespace OsEngine.OsTrader
                 nRow.Cells.Add(new DataGridViewTextBoxCell());
                 nRow.Cells[16].Value = position.ProfitOrderPrice.ToStringWithNoEndZero();
 
+                nRow.Cells.Add(new DataGridViewTextBoxCell());
+                nRow.Cells[17].Value = position.SignalTypeOpen;
+
+                nRow.Cells.Add(new DataGridViewTextBoxCell());
+                nRow.Cells[18].Value = position.SignalTypeClose;
+
                 return nRow;
             }
             catch (Exception error)


### PR DESCRIPTION
добавил SignalType Open/Close в позиции журнала. поможет анализировать статистику, какой из входов\выходов лучше, а то сейчас не совсем понятно, какой именно был вход\выход, если их предполагается несколько в стратегии.
![signal_type](https://user-images.githubusercontent.com/8736349/92367493-236e9d80-f0ff-11ea-9235-b8e1d512486d.png)

