### PR TITLE
fix. load seconds tf crashes tester ui

### DIFF
--- a/project/OsEngine/Market/Servers/Tester/TesterServerUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/Tester/TesterServerUi.xaml.cs
@@ -794,6 +794,13 @@ namespace OsEngine.Market.Servers.Tester
                         comboBox.Items.Add(TimeFrame.Min15.ToString());
                         comboBox.Items.Add(TimeFrame.Min30.ToString());
                         comboBox.Items.Add(TimeFrame.Min45.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec1.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec2.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec5.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec10.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec15.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec20.ToString());
+                        comboBox.Items.Add(TimeFrame.Sec30.ToString());
 
                         nRow.Cells.Add(comboBox);
                         nRow.Cells[2].Value = securities[i].TimeFrame.ToString();


### PR DESCRIPTION
проблема. [http://o-s-a.net/forum/threads/769](http://o-s-a.net/forum/threads/769 )
как воспроизвести.
1. скачиваем сет секундных данных
2. загружаем этот сет в тестер
3. у тестера нет секунд в комбобоксе. изза этого он кидает ошибку, пытается показать дефолтный Daily таймфрейм, а потом вообще падает.
![2020-10-12 10_53_59-Os Data](https://user-images.githubusercontent.com/8736349/95719991-531e4180-0c79-11eb-9d38-0b041843d53c.png)
![tester_seconds_error](https://user-images.githubusercontent.com/8736349/95719417-72689f00-0c78-11eb-9703-34df824974bd.png)
![2020-10-12 10_29_29-Exchange emulator](https://user-images.githubusercontent.com/8736349/95719425-74326280-0c78-11eb-9857-b69a0134e046.png)
![2020-10-12 10_30_00-Exchange emulator](https://user-images.githubusercontent.com/8736349/95720817-641b8280-0c7a-11eb-8c85-2d55eaf3c11d.png)

а вот после фикса.
![2020-10-12 10_31_50-](https://user-images.githubusercontent.com/8736349/95720719-464e1d80-0c7a-11eb-9c81-da188c2df981.png)
