### PR TITLE
Update TransaqServer.cs

### DIFF
--- a/project/OsEngine/Market/Servers/Transaq/TransaqServer.cs
+++ b/project/OsEngine/Market/Servers/Transaq/TransaqServer.cs
@@ -466,10 +466,7 @@ namespace OsEngine.Market.Servers.Transaq
 
             if (needSec.NameClass == "TQBR")
             {
-                if (side == "S")
-                {
-                    cmd += "<usecredit> true </usecredit>";
-                }
+                cmd += "<usecredit> true </usecredit>";
             }
             
             cmd += "</command>";


### PR DESCRIPTION
Параметр usecredit позволяет использовать плечо в режиме торгов TQBR как для Sell ордеров, так и для Buy. Если существующее условие, то в случае Buy с плечом сервер Transaq возвращает ошибку "Не хватает денежных средств (макс. допустимое количество 0 лот.)"