### PR TITLE
fix: lot size at Binance

### DIFF
--- a/project/OsEngine/Entity/Position.cs
+++ b/project/OsEngine/Entity/Position.cs
@@ -978,7 +978,7 @@ namespace OsEngine.Entity
 
             if (OpenOrders != null && OpenOrders.Count > 0)
             {
-                if (LotServers.Find(x => x == OpenOrders[0].ServerType) == null)
+                if (LotServers.Find(x => x == OpenOrders[0].ServerType) ==  ServerType.None)
                 {
                     return false;
                 }

--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
@@ -612,8 +612,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
                 security.NameClass = sec.quoteAsset;
                 security.NameId = sec.symbol + sec.quoteAsset;
                 security.SecurityType = SecurityType.Futures;
-                // sec.filters[1] - минимальный объем равный цена * объем
-                security.Lot = 1;
+                security.Lot = sec.filters[1].minQty.ToDecimal();
                 security.PriceStep = sec.filters[0].tickSize.ToDecimal();
                 security.PriceStepCost = security.PriceStep;
 


### PR DESCRIPTION
1) размер минимального объема по бумаге на Binance может быть от 0.001 до 1. 
2) поправил, чтобы правильно считался профит на НЕлотовых биржах.