### PR TITLE
fix: close position less 5usd at Binance

### DIFF
--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceClientFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceClientFutures.cs
@@ -907,6 +907,12 @@ namespace OsEngine.Market.Servers.Binance.Futures
                     param.Add("&quantity=",
                         order.Volume.ToString(CultureInfo.InvariantCulture)
                             .Replace(CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator, "."));
+
+                    if (!HedgeMode && order.PositionConditionType == OrderPositionConditionType.Close)
+                    {
+                        param.Add("&reduceOnly=", "true");
+                    }
+
                     if (order.TypeOrder == OrderPriceType.Limit)
                     {
                         param.Add("&timeInForce=", "GTC");


### PR DESCRIPTION
нашел 2 случая, когда позиция получается меньше 5баксов и робот ее не может закрыть вообще (идут ошибки что ордер меньше 5баксов).
1) ордер исполнился частично, а остальное отменили, ибо цена ушла
2) купили 1 лот при стоимости 5.50$, а потом цена упала до 4.8$ например.

добавил:
 **reduceOnly=true** флаг, который поможет закрыть позу при любом раскладе. (работает только в обычном режиме, hedge_mode исключаем)