### PR TITLE
feat: save security settings when download using OsData

### DIFF
--- a/project/OsEngine/OsData/OsDataSet.cs
+++ b/project/OsEngine/OsData/OsDataSet.cs
@@ -12,6 +12,7 @@ using OsEngine.Market.Servers;
 using OsEngine.Market.Servers.Finam;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -979,6 +980,46 @@ namespace OsEngine.OsData
             }
 
             string pathToSet = "Data\\" + SetName + "\\";
+
+            // save security settings / сохраняем информацию о контракте
+            IServer myServer = ServerMaster.GetServers().Find(server => server.ServerType == Source);
+            List<Security> securities = myServer.Securities;
+            List<string[]> saves = new List<string[]>();
+            CultureInfo culture = new CultureInfo("ru-RU");
+            for (int i = 0; i < securities.Count; i++)
+            {
+                saves.Add(new[]
+                {
+                    securities[i].Name,
+                    securities[i].Lot.ToString(culture),
+                    securities[i].Go > 0 ? securities[i].Go.ToString(culture) : "1",
+                    securities[i].PriceStepCost.ToString(culture),
+                    securities[i].PriceStep.ToString(culture)
+                });
+            }
+            try
+            {
+                using (StreamWriter writer = new StreamWriter(pathToSet + "SecuritiesSettings.txt", false))
+                {
+                    // name, lot, GO, price step, cost of price step / Имя, Лот, ГО, Цена шага, стоимость цены шага
+                    for (int i = 0; i < saves.Count; i++)
+                    {
+                        writer.WriteLine(
+                            saves[i][0] + ".txt$" +
+                            saves[i][1] + "$" +
+                            saves[i][2] + "$" +
+                            saves[i][3] + "$" +
+                            saves[i][4]
+                        );
+                    }
+
+                    writer.Close();
+                }
+            }
+            catch (Exception)
+            {
+                // send to the log / отправить в лог
+            }
 
             // candles/свечи
 


### PR DESCRIPTION
сохраняем инфу о контрактах в SecuritiesSettings.txt,  когда скачиваем сет данных из OsData. 
нужно для Тестера, чтобы руками lot_size не заполнять каждый раз для Бинанса например.
