### PR TITLE
fix: trade side direction for historical trades at Binance

### DIFF
--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceClientFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceClientFutures.cs
@@ -550,7 +550,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
                 trade.Volume = Math.Abs(StringToDecimal(jtTrade.Q));
                 trade.SecurityNameCode = secName;
 
-                if (StringToDecimal(jtTrade.Q) >= 0)
+                if (jtTrade.m)
                 {
                     trade.Side = Side.Buy;
                     trade.Ask = 0;
@@ -558,7 +558,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
                     trade.Bid = trade.Price;
                     trade.BidsVolume = trade.Volume;
                 }
-                else if (StringToDecimal(jtTrade.Q) < 0)
+                else
                 {
                     trade.Side = Side.Sell;
                     trade.Ask = trade.Price;

--- a/project/OsEngine/Market/Servers/Binance/Futures/Entity/AgregatedHistoryTrade.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/Entity/AgregatedHistoryTrade.cs
@@ -9,6 +9,21 @@ namespace OsEngine.Market.Servers.Binance.Futures.Entity
 {
     public partial class AgregatedHistoryTrade
     {
+        /*
+        https://binance-docs.github.io/apidocs/spot/en/#compressed-aggregate-trades-list
+
+        {
+            "a": 26129,         // Aggregate tradeId
+            "p": "0.01633102",  // Price
+            "q": "4.70443515",  // Quantity
+            "f": 27781,         // First tradeId
+            "l": 27781,         // Last tradeId
+            "T": 1498793709153, // Timestamp
+            "m": true,          // Was the buyer the maker?
+            "M": true           // Was the trade the best price match?
+        }
+        */
+
         [JsonProperty("a")]
         public long A { get; set; }
 
@@ -28,6 +43,9 @@ namespace OsEngine.Market.Servers.Binance.Futures.Entity
         public long T { get; set; }
 
         [JsonProperty("m")]
+        public bool m { get; set; }
+
+        [JsonProperty("M")]
         public bool M { get; set; }
     }
 }


### PR DESCRIPTION
поправил направление сделок для загружаемых исторических трейдов на Бинансе.
А то сейчас все сделки в Buy.
