### PR TITLE
Update TransaqServer.cs

### DIFF
--- a/project/OsEngine/Market/Servers/Transaq/TransaqServer.cs
+++ b/project/OsEngine/Market/Servers/Transaq/TransaqServer.cs
@@ -864,7 +864,7 @@ namespace OsEngine.Market.Servers.Transaq
 
             if (!string.IsNullOrEmpty(clientInfo.Union))
             {
-                var needClient = _clients.Find(c => string.IsNullOrEmpty(c.Union));
+                var needClient = _clients.Find(c => string.IsNullOrEmpty(clientInfo.Union));
 
                 if (needClient == null)
                 {


### PR DESCRIPTION
Исправление для добавления union портфеля, в случае если _clients уже имеет записи. В текущей реализации поиск возвращает запись у которой union == null, получается если есть mono счета и они пришли первыми, то union не добавится никогда.