### PR TITLE
feat: remove BotTabIndex historical candles from memory

### DIFF
--- a/project/OsEngine/Market/Servers/AServer.cs
+++ b/project/OsEngine/Market/Servers/AServer.cs
@@ -197,13 +197,13 @@ namespace OsEngine.Market.Servers
 
         private ServerParameterBool _neadToSaveCandlesParam;
 
-        private ServerParameterInt _neadToSaveCandlesCountParam;
+        public ServerParameterInt _neadToSaveCandlesCountParam;
 
         private ServerParameterBool _needToLoadBidAskInTrades;
 
         private ServerParameterBool _needToRemoveTradesFromMemory;
 
-        private ServerParameterBool _needToRemoveCandlesFromMemory;
+        public ServerParameterBool _needToRemoveCandlesFromMemory;
 
         public bool NeedToHideParams = false;
 

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabIndex.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabIndex.cs
@@ -338,7 +338,7 @@ namespace OsEngine.OsTrader.Panels.Tab
                             // ignore
                         }
                     }
-                    if (_startProgram == StartProgram.IsOsTrader)
+                    if (_startProgram == StartProgram.IsOsTrader && Tabs.Count > 0)
                     {
                         var candlesToKeep = ((OsEngine.Market.Servers.AServer)Tabs[0].MyServer)._neadToSaveCandlesCountParam.Value;
                         var needToRemove = ((OsEngine.Market.Servers.AServer)Tabs[0].MyServer)._needToRemoveCandlesFromMemory.Value;

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabIndex.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabIndex.cs
@@ -338,6 +338,19 @@ namespace OsEngine.OsTrader.Panels.Tab
                             // ignore
                         }
                     }
+                    if (_startProgram == StartProgram.IsOsTrader)
+                    {
+                        var candlesToKeep = ((OsEngine.Market.Servers.AServer)Tabs[0].MyServer)._neadToSaveCandlesCountParam.Value;
+                        var needToRemove = ((OsEngine.Market.Servers.AServer)Tabs[0].MyServer)._needToRemoveCandlesFromMemory.Value;
+
+                        if (needToRemove
+                            && Candles[Candles.Count - 1].TimeStart.Minute % 15 == 0
+                            && Candles[Candles.Count - 1].TimeStart.Second == 0
+                            && Candles.Count > candlesToKeep)
+                        {
+                            Candles.RemoveRange(0, Candles.Count - 1 - candlesToKeep);
+                        }
+                    }
 
                     _chartMaster.SetCandles(Candles);
 


### PR DESCRIPTION
удаление исторических свечей для BotTabIndex каждые 15 минут чтобы не занимали память.
активация флагом:
![image](https://user-images.githubusercontent.com/8736349/120782032-46b16680-c532-11eb-9a59-320908268a59.png)
оставляется количество свежих свечей из параметра:
![image](https://user-images.githubusercontent.com/8736349/120782561-cd664380-c532-11eb-8ba2-e9cfe8ce68f8.png)

итог: **удаляются свечи из обычных вкладок и индекса (вместе с его вкладками) + перестраиваются индикаторы и myTrades**