### PR TITLE
feat: binance. mark price and funding rate in realtime

### DIFF
--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceClientFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceClientFutures.cs
@@ -241,6 +241,30 @@ namespace OsEngine.Market.Servers.Binance.Futures
         }
 
         /// <summary>
+        /// get realtime Mark Price and Funding Rate
+        /// получать среднюю цену инструмента (на всех биржах) и ставку фандирования в реальном времени
+        /// </summary>
+        public PremiumIndex GetPremiumIndex(string symbol)
+        {
+            try
+            {
+                var res = CreateQuery(
+                    Method.GET,
+                    "/" + type_str_selector + "/v1/premiumIndex",
+                    new Dictionary<string, string>() { { "symbol=", symbol } },
+                    true);
+
+                PremiumIndex resp = JsonConvert.DeserializeAnonymousType(res, new PremiumIndex());
+                return resp;
+            }
+            catch (Exception ex)
+            {
+                SendLogMessage(ex.ToString(), LogMessageType.Error);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// shows whether connection works
         /// работает ли соединение
         /// </summary>

--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
@@ -306,6 +306,16 @@ namespace OsEngine.Market.Servers.Binance.Futures
         /// </summary>
         public ServerConnectStatus ServerStatus { get; set; }
 
+
+        /// <summary>
+        /// get realtime Mark Price and Funding Rate
+        /// получать среднюю цену инструмента (на всех биржах) и ставку фандирования в реальном времени
+        /// </summary>
+        public PremiumIndex GetPremiumIndex(string symbol)
+        {
+            return _client.GetPremiumIndex(symbol);
+        }
+
         /// <summary>
         /// request instrument history
         /// запрос истории по инструменту

--- a/project/OsEngine/Market/Servers/Binance/Futures/Entity/AccountResponseFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/Entity/AccountResponseFutures.cs
@@ -87,4 +87,14 @@ namespace OsEngine.Market.Servers.Binance.Futures.Entity
     {
         public bool dualSidePosition;
     }
+
+    public class PremiumIndex
+    {
+        public string symbol;                       //"BTCUSDT",
+        public string markPrice;                    //"11793.63104562",  // mark price
+        public string indexPrice;                   //"11781.80495970", // index price
+        public string lastFundingRate;              //"0.00038246",  // This is the lasted funding rate
+        public string nextFundingTime;              //1597392000000,
+        public string interestRate;                 //0.00010000",
+    }
 }


### PR DESCRIPTION
метод для получения средней цены инструмента (на всех биржах) и ставки фандирования в реальном времени из робота.

пример использования:
![image](https://user-images.githubusercontent.com/8736349/130424425-72635eab-3dda-46ea-963d-7e9dc22bd338.png)
