### PR TITLE
add server-list window

### DIFF
--- a/project/OsEngine/MainWindow.xaml
+++ b/project/OsEngine/MainWindow.xaml
@@ -2,26 +2,26 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Main menu" Style="{StaticResource WindowStyleNoResize}" Height="315" Width="625" ResizeMode="CanMinimize" WindowStartupLocation="CenterScreen" Icon="Images/OsLogo.ico">
-    <Grid>
-        <Rectangle Margin="429,7,10,0" Height="205" VerticalAlignment="Top" />
-        <Rectangle Margin="222,7,202,0" Height="205" VerticalAlignment="Top" />
-        <Rectangle Margin="10,7,409,0" Height="205" VerticalAlignment="Top" />
-        <Button  x:Name="ButtonRobot" Content="Bot Station" Margin="448,171,0,0" VerticalAlignment="Top" Click="ButtonRobotCandleOne_Click" HorizontalAlignment="Left" Width="146" Height="28" />
-        <Button  x:Name="ButtonTester" Content="Tester" Margin="246,105,0,0" VerticalAlignment="Top" Click="ButtonTesterCandleOne_Click" HorizontalAlignment="Left" Width="146" Height="28"   />
-        <Button  x:Name="ButtonData" Content="Data" Margin="37,105,0,0" VerticalAlignment="Top" Click="ButtonData_Click" HorizontalAlignment="Left" Width="146" Height="28" />
-        <Button  x:Name="ButtonCandleConverter" Content="Candle Converter" HorizontalAlignment="Left" Margin="37,172,0,0" VerticalAlignment="Top" Width="145" Click="CandleConverter_Click"/>
-        <Button  x:Name="ButtonConverter" Content="Converter" Margin="37,138,0,0" VerticalAlignment="Top" Click="ButtonConverter_Click" Height="28" HorizontalAlignment="Left" Width="146" />
-        <Button  x:Name="ButtonOptimizer" Content="Optimizer" Margin="246,138,0,0" VerticalAlignment="Top" Click="ButtonOptimizer_Click" HorizontalAlignment="Left" Width="146" Height="28"  />
-        <Button  x:Name="ButtonMiner" Content="Miner" Margin="246,171,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="146" Height="28" Click="ButtonMiner_Click"  />
-        <Label Name="BlockDataLabel" Content="Work with data" HorizontalAlignment="Center" HorizontalContentAlignment="Center"  Margin="12,36,408.667,0" VerticalAlignment="Top" Width="202" Height="82" FontSize="28" Foreground="#FFA7A8AA"/>
-        <Label Name="BlockTestingLabel" Content="Testing" HorizontalAlignment="Center" HorizontalContentAlignment="Center" Margin="222,56,202,0" VerticalAlignment="Top" Width="197" FontSize="28" Foreground="#FFA7A8AA" Height="49"/>
-        <Label Name="BlockTradingLabel" Content="Trading" HorizontalAlignment="Center" HorizontalContentAlignment="Center"  Margin="429,54,10,0" VerticalAlignment="Top"  FontSize="28" Foreground="#FFA7A8AA" Height="51" Width="182"/>
-        <Image HorizontalAlignment="Left" Source="Images/MainWIndow/test.png" Height="60" Margin="292,7,0,0" VerticalAlignment="Top" Width="60"/>
-        <Image HorizontalAlignment="Left" Source="Images/MainWIndow/data.png" Height="68" Margin="76,7,0,0" VerticalAlignment="Top" Width="68"/>
-        <Image HorizontalAlignment="Left" Source="Images/MainWIndow/Trading.png" Height="85" Margin="484,0,0,0" VerticalAlignment="Top" Width="85"/>
-        <Rectangle Margin="10,220,10,10" />
-        <Button Name="ButtonSettings" HorizontalAlignment="Left" Margin="268,231,0,0" VerticalAlignment="Top" Width="100" Height="28" Click="ButtonSettings_Click">
-            <Image x:Name="ImageGear" HorizontalAlignment="Left" Source="Images/MainWIndow/gear.png" Width="24" Height="24"/>
-        </Button>
-    </Grid>
+	<Grid>
+		<Rectangle Margin="429,7,10,0" Height="205" VerticalAlignment="Top" />
+		<Rectangle Margin="222,7,202,0" Height="205" VerticalAlignment="Top" />
+		<Rectangle Margin="10,7,409,0" Height="205" VerticalAlignment="Top" />
+		<Button  x:Name="ButtonRobot" Content="Bot Station" Margin="448,171,0,0" VerticalAlignment="Top" Click="ButtonRobotCandleOne_Click" HorizontalAlignment="Left" Width="146" Height="28" />
+		<Button  x:Name="ButtonTester" Content="Tester" Margin="246,105,0,0" VerticalAlignment="Top" Click="ButtonTesterCandleOne_Click" HorizontalAlignment="Left" Width="146" Height="28"   />
+		<Button  x:Name="ButtonData" Content="Data" Margin="37,105,0,0" VerticalAlignment="Top" Click="ButtonData_Click" HorizontalAlignment="Left" Width="146" Height="28" />
+		<Button  x:Name="ButtonCandleConverter" Content="Candle Converter" HorizontalAlignment="Left" Margin="37,172,0,0" VerticalAlignment="Top" Width="145" Click="CandleConverter_Click"/>
+		<Button  x:Name="ButtonConverter" Content="Converter" Margin="37,138,0,0" VerticalAlignment="Top" Click="ButtonConverter_Click" Height="28" HorizontalAlignment="Left" Width="146" />
+		<Button  x:Name="ButtonOptimizer" Content="Optimizer" Margin="246,138,0,0" VerticalAlignment="Top" Click="ButtonOptimizer_Click" HorizontalAlignment="Left" Width="146" Height="28"  />
+		<Button  x:Name="ButtonMiner" Content="Miner" Margin="246,171,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="146" Height="28" Click="ButtonMiner_Click"  />
+		<Label Name="BlockDataLabel" Content="Work with data" HorizontalAlignment="Center" HorizontalContentAlignment="Center"  Margin="12,56,409,0" VerticalAlignment="Top" Width="202" Height="44" FontSize="28" Foreground="#FFA7A8AA"/>
+		<Label Name="BlockTestingLabel" Content="Testing" HorizontalAlignment="Center" HorizontalContentAlignment="Center" Margin="222,56,202,0" VerticalAlignment="Top" Width="197" FontSize="28" Foreground="#FFA7A8AA" Height="49"/>
+		<Label Name="BlockTradingLabel" Content="Trading" HorizontalAlignment="Center" HorizontalContentAlignment="Center"  Margin="429,54,10,0" VerticalAlignment="Top"  FontSize="28" Foreground="#FFA7A8AA" Height="51" Width="182"/>
+		<Image HorizontalAlignment="Left" Source="Images/MainWIndow/test.png" Height="60" Margin="292,7,0,0" VerticalAlignment="Top" Width="60"/>
+		<Image HorizontalAlignment="Left" Source="Images/MainWIndow/data.png" Height="68" Margin="76,7,0,0" VerticalAlignment="Top" Width="68"/>
+		<Image HorizontalAlignment="Left" Source="Images/MainWIndow/Trading.png" Height="85" Margin="484,0,0,0" VerticalAlignment="Top" Width="85"/>
+		<Rectangle Margin="10,220,10,10" />
+		<Button Name="ButtonSettings" HorizontalAlignment="Left" Margin="268,231,0,0" VerticalAlignment="Top" Width="100" Height="28" Click="ButtonSettings_Click">
+			<Image x:Name="ImageGear" HorizontalAlignment="Left" Source="Images/MainWIndow/gear.png" Width="24" Height="24"/>
+		</Button>
+	</Grid>
 </Window>

--- a/project/OsEngine/OsData/OsDataConnectorList.xaml
+++ b/project/OsEngine/OsData/OsDataConnectorList.xaml
@@ -1,0 +1,10 @@
+﻿<Window x:Class="OsEngine.OsData.OsDataConnectorList"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Os.Data.ConnectorLict" Height="825" Width="350" WindowStartupLocation="CenterScreen" Style="{StaticResource WindowStyleCanResize}" 
+		MinWidth="220" MinHeight="360" Icon="/Images/OsLogo.ico" Closing="Window_Closing">
+    <Grid Name="GridPrime">
+        <WindowsFormsHost Name="hSource" Margin="15,16,15,56"/>
+        <Button  x:Name="ButtonSaveClose" Content="Save and Close" Margin="20,16" VerticalAlignment="Bottom" Click="ButtonSaveClose_Click" HorizontalAlignment="Right" Width="106" Height="28" />
+    </Grid>
+</Window>

--- a/project/OsEngine/OsData/OsDataConnectorList.xaml.cs
+++ b/project/OsEngine/OsData/OsDataConnectorList.xaml.cs
@@ -1,0 +1,178 @@
+﻿using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows;
+using System.IO;
+//using System.Windows.Media;
+
+using OsEngine.Market;
+using OsEngine.Language;
+using OsEngine.Entity;
+using System.Windows.Forms;
+
+namespace OsEngine.OsData
+{
+    /// <summary>
+    /// Логика взаимодействия для OsDataConnectorList.xaml
+    /// </summary>
+    public partial class OsDataConnectorList : Window
+    {
+		private DataGridView _grid;
+		private List<ServerType> availableServers;
+
+		public OsDataConnectorList()
+        {
+            InitializeComponent();
+
+			availableServers = ServerMaster.ServersTypes;
+
+			SysInitTheGrid();
+			SysPushDataToTheGrid();
+		}
+
+        private void ButtonSaveClose_Click(object sender, RoutedEventArgs e)
+        {
+			this.Close();
+        }
+		private DataGridViewColumn SysCreateGridColumn(DataGridViewCell inCell, string inHeader)
+		{
+			DataGridViewColumn ret = new DataGridViewColumn();
+			ret.CellTemplate = inCell;
+			ret.HeaderText = inHeader;
+			ret.ReadOnly = true;
+			return ret;
+		}
+		private void SysInitTheGrid(){
+			DataGridViewTextBoxCell cellName = new DataGridViewTextBoxCell();
+			DataGridViewCheckBoxCell cellState = new DataGridViewCheckBoxCell();
+			DataGridViewColumn currColumn;
+
+			_grid = DataGridFactory.GetDataGridView(DataGridViewSelectionMode.FullRowSelect, DataGridViewAutoSizeRowsMode.None);
+			_grid.AllowUserToResizeColumns = false;
+			_grid.AllowUserToResizeRows = false;
+
+			cellState.Style = _grid.DefaultCellStyle;
+			cellState.Style = _grid.DefaultCellStyle;
+
+			currColumn = SysCreateGridColumn(cellState, OsLocalization.Data.Label5);
+			currColumn.Width = 36;
+			_grid.Columns.Add(currColumn);
+
+			currColumn = SysCreateGridColumn(cellName, OsLocalization.Data.Label4);
+			currColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+			_grid.Columns.Add(currColumn);
+
+			_grid.Click += CheckBoxPaintOnOff_Click;
+			
+			hSource.Child = _grid;
+
+			//    _gridSources = newGrid;
+			//    _gridSources.DoubleClick += _gridSources_DoubleClick;		//	реализовать это
+			//    _hostSource.Child = _gridSources;
+			//   _hostSource.VerticalAlignment = VerticalAlignment.Top;
+		}
+
+
+		private void SysPushDataToTheGrid(){
+			if(_grid.InvokeRequired){
+				_grid.Invoke(new Action(SysPushDataToTheGrid));
+				return;
+			}
+
+			DataGridViewRow currRow;
+			_grid.Rows.Clear();
+
+			List<string> usedServers = UsedServersGet();
+
+			for (int i=0; i< availableServers.Count; i++){
+				currRow = new DataGridViewRow();
+				currRow.Cells.Add(new DataGridViewCheckBoxCell());
+				currRow.Cells.Add(new DataGridViewTextBoxCell());
+
+				currRow.Cells[0].Value = usedServers.Contains(availableServers[i].ToString());
+				currRow.Cells[0].Style.Alignment = DataGridViewContentAlignment.MiddleCenter;
+				currRow.Cells[1].Value = availableServers[i];
+				currRow.Cells[1].Style.Alignment = DataGridViewContentAlignment.MiddleLeft;
+
+				_grid.Rows.Add(currRow);
+			}
+		}
+
+		public void UsedServersSave(List<string> inUsedServers)
+		{
+			try
+			{
+				if (!Directory.Exists("Data\\"))
+				{
+					Directory.CreateDirectory("Data\\");
+				}
+				using (StreamWriter writer = new StreamWriter("Data\\UsedServers.txt", false))
+				{
+					foreach (string currStr in inUsedServers)
+					{
+						writer.WriteLine(currStr);
+					}
+					writer.Close();
+				}
+			}
+			catch (Exception)
+			{
+				// ignored
+			}
+		}
+
+		public static List<string> UsedServersGet()
+		{
+			List<string> ret = new List<string>();
+			string currStr;
+
+			if (!File.Exists("Data\\UsedServers.txt")) { return ret; }
+
+			using (StreamReader reader = new StreamReader("Data\\UsedServers.txt"))
+			{
+				while (!reader.EndOfStream)
+				{
+					currStr = reader.ReadLine();
+					ret.Add(currStr);
+				}
+				reader.Close();
+			}
+
+			return ret;
+		}
+
+		public void CheckBoxPaintOnOff_Click(object sender, EventArgs e){
+
+			DataGridView thisGrid = sender as DataGridView;
+			if (thisGrid is null) { return; }
+
+			int cRow = thisGrid.CurrentCell.RowIndex;
+			thisGrid.Rows[cRow].Cells[0].Value = !(bool)(thisGrid.Rows[cRow].Cells[0].Value);
+
+			//System.Windows.MessageBox.Show(" selected " + thisGrid.CurrentCell.RowIndex);
+
+			List<string> usedServers = new List<string>();
+			foreach(DataGridViewRow currRow in thisGrid.Rows){
+				if((bool)currRow.Cells[0].Value == true){
+					usedServers.Add(currRow.Cells[1].Value.ToString());
+				}
+			}
+			UsedServersSave(usedServers);
+		}
+
+		private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+		{
+
+		}
+	}
+}

--- a/project/OsEngine/OsData/OsDataMaster.cs
+++ b/project/OsEngine/OsData/OsDataMaster.cs
@@ -246,7 +246,7 @@ namespace OsEngine.OsData
         /// <summary>
         /// redraw the source table/перерисовать таблицу источников
         /// </summary>
-        private void RePaintSourceGrid()
+        public void RePaintSourceGrid()
         {
             if (_gridSources.InvokeRequired)
             {
@@ -264,8 +264,10 @@ namespace OsEngine.OsData
             {
                 serversCreate = new List<IServer>();
             }
+			
+			List<string> usedServers = OsDataConnectorList.UsedServersGet();
 
-            for (int i = 0; i < servers.Count; i++)
+			for (int i = 0; i < servers.Count; i++)
             {
                 DataGridViewRow row1 = new DataGridViewRow();
                 row1.Cells.Add(new DataGridViewTextBoxCell());
@@ -277,6 +279,7 @@ namespace OsEngine.OsData
                 if (server == null)
                 {
                     row1.Cells[1].Value = "Disabled";
+					if(usedServers.Contains(servers[i].ToString()) == false){		continue;		}
                 }
                 else if (server != null && server.ServerStatus == ServerConnectStatus.Connect)
                 {

--- a/project/OsEngine/OsData/OsDataUi.xaml
+++ b/project/OsEngine/OsData/OsDataUi.xaml
@@ -11,6 +11,7 @@
         <Grid Margin="0,5,5,172" HorizontalAlignment="Right" Width="305" Grid.RowSpan="2">
             <Rectangle/>
             <Label Name="Label4" Content="Source" HorizontalAlignment="Left" VerticalAlignment="Top" FontWeight="ExtraBlack" Margin="10,0,0,0" FontSize="18" Height="31" />
+            <Button  x:Name="ButtonChangeSrc" Content="Add / Del" Margin="0,0,10,0" VerticalAlignment="Top" Click="ButtonChangeSrc_Click" HorizontalAlignment="Right" Width="86" Height="28" />
             <WindowsFormsHost Name="HostSource" Height="155" Margin="5,31,5,0" VerticalAlignment="Top"/>
             <CheckBox Name="CheckBoxPaintOnOff" Content="Chart is paining" HorizontalAlignment="Left" Margin="10,218,0,0" VerticalAlignment="Top"/>
             <Label Name="Label24" Content="Sets" HorizontalAlignment="Left" VerticalAlignment="Top" FontWeight="ExtraBlack" Margin="10,188,0,0" FontSize="18" />

--- a/project/OsEngine/OsData/OsDataUi.xaml.cs
+++ b/project/OsEngine/OsData/OsDataUi.xaml.cs
@@ -58,5 +58,16 @@ namespace OsEngine.OsData
                 e.Cancel = true;
             }
         }
+
+        private void ButtonChangeSrc_Click(object sender, RoutedEventArgs e)
+        {
+            OsDataConnectorList ui = new OsDataConnectorList();
+            ui.ShowDialog();
+
+			// следующее выполненится плсле закрытия диалога 
+			//  MessageBox.Show("AAAA");
+
+			_osDataMaster.RePaintSourceGrid();
+		}
     }
 }

--- a/project/OsEngine/OsEngine.csproj
+++ b/project/OsEngine/OsEngine.csproj
@@ -772,6 +772,9 @@
     <Compile Include="OsConverter\OsCandleConverterUi.xaml.cs">
       <DependentUpon>OsCandleConverterUi.xaml</DependentUpon>
     </Compile>
+    <Compile Include="OsData\OsDataConnectorList.xaml.cs">
+      <DependentUpon>OsDataConnectorList.xaml</DependentUpon>
+    </Compile>
     <Compile Include="OsMiner\OsMinerMaster.cs" />
     <Compile Include="OsMiner\OsMinerSet.cs" />
     <Compile Include="OsMiner\OsMinerSetUi.xaml.cs">
@@ -1300,6 +1303,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="OsConverter\OsCandleConverterUi.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="OsData\OsDataConnectorList.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
добавил в модуль OsData окно выбора серверов и кнопку для его вызова.

Проблема: 
Длинный список серверов отображается внутри маленького квадрата без полос прокрутки. Неудобное перемещение в низ списка.

Решение:
Все доступные сервера переехали в отдельную таблицу с флажками.
Сервер отображается где и раньше если у него установлен флажок или к нему пытались подключаться в текущей сессии.

После изменений заметил что большой список фигурирует и в других модулях. Портируйте решение самостоятельно. если считаете коммит полезным.

В MainWindow.xaml надпись "Работа с данными" залазила на кнопку "Дата". Поправил некрасиво, в коммит попало случайно.