### PR TITLE
fix smartcom compilation error

### DIFF
--- a/project/OsEngine/Entity/CandleManager.cs
+++ b/project/OsEngine/Entity/CandleManager.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using OsEngine.Logging;
@@ -19,7 +20,9 @@ using OsEngine.Market.Servers.BitMex;
 using OsEngine.Market.Servers.GateIo;
 using OsEngine.Market.Servers.Kraken;
 using OsEngine.Market.Servers.QuikLua;
+#if SmartComEnabled
 using OsEngine.Market.Servers.SmartCom;
+#endif
 using OsEngine.Market.Servers.Tester;
 using OsEngine.Market.Servers.Transaq;
 using OsEngine.Market.Servers.ZB;
@@ -286,6 +289,7 @@ namespace OsEngine.Entity
                         }
                         else if (serverType == ServerType.SmartCom)
                         {
+#if SmartComEnabled
                             SmartComServer smart = (SmartComServer) _server;
 
                             if (series.CandleCreateMethodType != CandleCreateMethodType.Simple ||
@@ -307,6 +311,10 @@ namespace OsEngine.Entity
                             }
                             series.UpdateAllCandles();
                             series.IsStarted = true;
+#else
+                            Trace.Fail("SmartCom is disabled", 
+                                "To enable SmartCom uncomment constant 'SmartComEnabled' in OsEngine.csproj file"); 
+#endif
                         }
                         else if (serverType == ServerType.Tinkoff)
                         {

--- a/project/OsEngine/Entity/CandleManager.cs
+++ b/project/OsEngine/Entity/CandleManager.cs
@@ -20,7 +20,7 @@ using OsEngine.Market.Servers.BitMex;
 using OsEngine.Market.Servers.GateIo;
 using OsEngine.Market.Servers.Kraken;
 using OsEngine.Market.Servers.QuikLua;
-#if SmartComEnabled
+#if SMART_COM
 using OsEngine.Market.Servers.SmartCom;
 #endif
 using OsEngine.Market.Servers.Tester;
@@ -289,7 +289,7 @@ namespace OsEngine.Entity
                         }
                         else if (serverType == ServerType.SmartCom)
                         {
-#if SmartComEnabled
+#if SMART_COM
                             SmartComServer smart = (SmartComServer) _server;
 
                             if (series.CandleCreateMethodType != CandleCreateMethodType.Simple ||
@@ -313,7 +313,7 @@ namespace OsEngine.Entity
                             series.IsStarted = true;
 #else
                             Trace.Fail("SmartCom is disabled", 
-                                "To enable SmartCom uncomment constant 'SmartComEnabled' in OsEngine.csproj file"); 
+                                "To enable SmartCom uncomment constant 'SMART_COM' in OsEngine.csproj file"); 
 #endif
                         }
                         else if (serverType == ServerType.Tinkoff)

--- a/project/OsEngine/Market/ServerMaster.cs
+++ b/project/OsEngine/Market/ServerMaster.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Forms.Integration;
@@ -32,7 +33,9 @@ using OsEngine.Market.Servers.Optimizer;
 using OsEngine.Market.Servers.Plaza;
 using OsEngine.Market.Servers.Quik;
 using OsEngine.Market.Servers.QuikLua;
+#if SmartComEnabled
 using OsEngine.Market.Servers.SmartCom;
+#endif
 using OsEngine.Market.Servers.Tester;
 using OsEngine.Market.Servers.Transaq;
 using OsEngine.Market.Servers.ZB;
@@ -314,7 +317,12 @@ namespace OsEngine.Market
                 }
                 else if (type == ServerType.SmartCom)
                 {
-                    newServer = new SmartComServer();
+#if SmartComEnabled
+                    newServer = new SmartComServer();   
+#else
+                    Trace.Fail("SmartCom is disabled", 
+                        "To enable SmartCom uncomment constant 'SmartComEnabled' in OsEngine.csproj file");                    
+#endif
                 }
                 else if (type == ServerType.Plaza)
                 {

--- a/project/OsEngine/Market/ServerMaster.cs
+++ b/project/OsEngine/Market/ServerMaster.cs
@@ -33,7 +33,7 @@ using OsEngine.Market.Servers.Optimizer;
 using OsEngine.Market.Servers.Plaza;
 using OsEngine.Market.Servers.Quik;
 using OsEngine.Market.Servers.QuikLua;
-#if SmartComEnabled
+#if SMART_COM
 using OsEngine.Market.Servers.SmartCom;
 #endif
 using OsEngine.Market.Servers.Tester;
@@ -317,11 +317,11 @@ namespace OsEngine.Market
                 }
                 else if (type == ServerType.SmartCom)
                 {
-#if SmartComEnabled
+#if SMART_COM
                     newServer = new SmartComServer();   
 #else
                     Trace.Fail("SmartCom is disabled", 
-                        "To enable SmartCom uncomment constant 'SmartComEnabled' in OsEngine.csproj file");                    
+                        "To enable SmartCom uncomment constant 'SMART_COM' in OsEngine.csproj file");                    
 #endif
                 }
                 else if (type == ServerType.Plaza)

--- a/project/OsEngine/Market/Servers/Tester/TesterServerUi.xaml
+++ b/project/OsEngine/Market/Servers/Tester/TesterServerUi.xaml
@@ -60,8 +60,8 @@
                     <CheckBox Name="CheckBoxSlipageStopOn" Content="In steps" HorizontalAlignment="Left" Margin="306,159,0,0" VerticalAlignment="Top" Checked="CheckBoxSlipageStopOn_Checked"/>
                     <Label Name="Label34" Content="Order execution" HorizontalAlignment="Right" Margin="0,84,79,0" VerticalAlignment="Top" FontSize="16" />
                     <CheckBox Name="CheckBoxExecutionOrderIntersection" Content="Price crossing" HorizontalAlignment="Left" Margin="566,125,0,0" VerticalAlignment="Top" Checked="CheckBoxExecutionOrderIntersection_Checked"/>
-                    <CheckBox Name="CheckBoxExecutionOrderTuch" Content="Price touch" HorizontalAlignment="Left" Margin="566,159,0,0" VerticalAlignment="Top" Cursor="" Checked="CheckBoxExecutionOrderTuch_Checked"/>
-                    <CheckBox Name="CheckBoxExecutionOrderFiftyFifty" Content="50 / 50" HorizontalAlignment="Left" Margin="566,195,0,0" VerticalAlignment="Top" Cursor="" Checked="CheckBoxExecutionOrderFiftyFifty_Checked"/>
+                    <CheckBox Name="CheckBoxExecutionOrderTuch" Content="Price touch" HorizontalAlignment="Left" Margin="566,159,0,0" VerticalAlignment="Top" Cursor="None" Checked="CheckBoxExecutionOrderTuch_Checked"/>
+                    <CheckBox Name="CheckBoxExecutionOrderFiftyFifty" Content="50 / 50" HorizontalAlignment="Left" Margin="566,195,0,0" VerticalAlignment="Top" Cursor="None" Checked="CheckBoxExecutionOrderFiftyFifty_Checked"/>
                 </Grid>
             </TabItem>
             <TabItem Name="Label31" Header=" Portfolio " FontSize="14">

--- a/project/OsEngine/OsEngine.csproj
+++ b/project/OsEngine/OsEngine.csproj
@@ -62,6 +62,12 @@
   <PropertyGroup>
     <ApplicationIcon>Images\OsLogo.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+    Uncomment next line to enable SmartCom
+    <DefineConstants>SmartComEnabled</DefineConstants>
+    -->
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="cgate_net64, Version=5.10.0.36987, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
@@ -80,6 +86,7 @@
       <HintPath>bin\Debug\LmaxClientLibrary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -118,8 +125,9 @@
       <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard1.1\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization">
       <Private>True</Private>
@@ -143,6 +151,16 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsFormsIntegration" />
+  </ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains(SmartComEnabled))">
+    <Compile Include="Market\Servers\SmartCom\SmartComServer.cs" />
+    <Compile Include="Market\Servers\SmartCom\SmartComServerUi.xaml.cs">
+      <DependentUpon>SmartComServerUi.xaml</DependentUpon>
+    </Compile>
+    <Page Include="Market\Servers\SmartCom\SmartComServerUi.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -692,10 +710,6 @@
     <Compile Include="Market\Servers\Entity\MarshalUTF8.cs" />
     <Compile Include="Market\Servers\Entity\ServerWorkingTimeSettings.cs" />
     <Compile Include="Market\Servers\Entity\TimeManager.cs" />
-    <Compile Include="Market\Servers\SmartCom\SmartComServer.cs" />
-    <Compile Include="Market\Servers\SmartCom\SmartComServerUi.xaml.cs">
-      <DependentUpon>SmartComServerUi.xaml</DependentUpon>
-    </Compile>
     <Compile Include="Market\Servers\Tester\GoToUi.xaml.cs">
       <DependentUpon>GoToUi.xaml</DependentUpon>
     </Compile>
@@ -1253,10 +1267,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Market\Servers\SmartCom\SmartComServerUi.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Page Include="Market\Servers\Tester\GoToUi.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1572,7 +1582,7 @@
     <None Include="Resources\Duck.wav" />
     <None Include="Resources\Bird.wav" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains(SmartComEnabled))">
     <COMReference Include="SmartCOM4Lib">
       <Guid>{D12929CB-4569-46B7-99CE-FFF546E41866}</Guid>
       <VersionMajor>1</VersionMajor>

--- a/project/OsEngine/OsEngine.csproj
+++ b/project/OsEngine/OsEngine.csproj
@@ -65,7 +65,7 @@
   <PropertyGroup>
     <!--
     Uncomment next line to enable SmartCom
-    <DefineConstants>SmartComEnabled</DefineConstants>
+    <DefineConstants>SMART_COM</DefineConstants>
     -->
   </PropertyGroup>
   <ItemGroup>
@@ -152,7 +152,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
-  <ItemGroup Condition="$(DefineConstants.Contains(SmartComEnabled))">
+  <ItemGroup Condition="$(DefineConstants.Contains(SMART_COM))">
     <Compile Include="Market\Servers\SmartCom\SmartComServer.cs" />
     <Compile Include="Market\Servers\SmartCom\SmartComServerUi.xaml.cs">
       <DependentUpon>SmartComServerUi.xaml</DependentUpon>
@@ -1582,7 +1582,7 @@
     <None Include="Resources\Duck.wav" />
     <None Include="Resources\Bird.wav" />
   </ItemGroup>
-  <ItemGroup Condition="$(DefineConstants.Contains(SmartComEnabled))">
+  <ItemGroup Condition="$(DefineConstants.Contains(SMART_COM))">
     <COMReference Include="SmartCOM4Lib">
       <Guid>{D12929CB-4569-46B7-99CE-FFF546E41866}</Guid>
       <VersionMajor>1</VersionMajor>

--- a/project/OsEngine/packages.config
+++ b/project/OsEngine/packages.config
@@ -3,4 +3,5 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="QUIKSharp" version="1.0.0" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Сделал так, чтобы проект компилировался сразу после скачивания. Без необходимости устанавливать SmartCom или менять исходники.
Для этого добавлена условная компиляция по наличию константы SMART_COM.
Если кому-то требуется использовать SmartCom, то теперь это делается правкой одной строки в файле OsEngine.proj, либо через UI в IDE:
![image](https://user-images.githubusercontent.com/1058104/153711086-fa4dcc44-8545-40f4-9811-abade5ac9150.png)

В противном случае, если попытаться использовать SmartCom, то будет выдано сообщение об ошибке с указанием, что необходимо сделать:
![image](https://user-images.githubusercontent.com/1058104/153711131-a392abdd-ffaa-4a15-af35-c4b606a5aad1.png)


