### PR TITLE
BinanceFutures listenKey renewal fixes

### DIFF
--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
@@ -102,6 +102,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
                 _client.NewTradesEvent -= _client_NewTradesEvent;
                 _client.MyTradeEvent -= _client_MyTradeEvent;
                 _client.MyOrderEvent -= _client_MyOrderEvent;
+                _client.ListenKeyExpiredEvent -= _client_ListenKeyExpiredEvent;
                 _client.LogMessageEvent -= SendLogMessage;
             }
 
@@ -129,6 +130,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
                 _client.NewTradesEvent += _client_NewTradesEvent;
                 _client.MyTradeEvent += _client_MyTradeEvent;
                 _client.MyOrderEvent += _client_MyOrderEvent;
+                _client.ListenKeyExpiredEvent += _client_ListenKeyExpiredEvent;
                 _client.LogMessageEvent += SendLogMessage;
             }
 
@@ -359,6 +361,18 @@ namespace OsEngine.Market.Servers.Binance.Futures
             }
 
             return candles;
+        }
+
+        /// <summary>
+        /// renewing of the expired listen key
+        /// обновление заэкспарившегося listen key
+        /// </summary>
+        void _client_ListenKeyExpiredEvent(BinanceClientFutures client)
+        {
+            if (client != null)
+            {
+                client.RenewListenKey();
+            }
         }
 
         //parsing incoming data


### PR DESCRIPTION
…ation because of listenKey expiration errors

1) Added listening listenKeyExpired event and handling of it via automatic renewing of the listenKey
2) Made listenKey keep alive HTTP requests be sent without necessity to wait for a thread unlocks

RU: Исправил 2 проблемы по BinanceFutures прерыванию сокет коннекшена из-за listenKey экспирации
1) Добавил подписку на listenKeyExpired событие и обработку путем автоматического обновления listenKey
2) Сделал отправку listenKey keep alive HTTP запросов без необходимости ждать анлока от других потоков