### PR TITLE
Fixed NRE issue during optimization process.

### DIFF
--- a/project/OsEngine/Market/ServerMaster.cs
+++ b/project/OsEngine/Market/ServerMaster.cs
@@ -116,6 +116,11 @@ namespace OsEngine.Market
             }
         }
 
+        public static bool HasActiveServers()
+        {
+            return _servers != null && _servers.Count > 0;
+        }
+
         public static List<ServerType> ActiveServersTypes
         {
             get

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabScreener.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabScreener.cs
@@ -234,7 +234,7 @@ namespace OsEngine.OsTrader.Panels.Tab
         /// </summary>
         public void TryLoadTabs()
         {
-            if (ServerMaster.ActiveServersTypes.Count == 0)
+            if (!ServerMaster.HasActiveServers())
             {
                 return;
             }


### PR DESCRIPTION
RU: Оптимизатору надо всего лишь узнать есть ли хоть один активный сервер. Для этого не надо делать перебоа всей коллекции потому что это требует много времени и в этот момент другой поток добавляет новый сервер после чего все приложение крешится.

EN: No need to go through whole collection when is is only needed to check if it is not empty. That avoids concurrency issue when during walk through whole collection new element is added by another thread.