### PR TITLE
Общее кол-во позиций в таблицу Скринера

### DIFF
--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabScreener.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabScreener.cs
@@ -149,7 +149,8 @@ namespace OsEngine.OsTrader.Panels.Tab
 
                     decimal last = 0;
 					
-					int posCount = tab.PositionsOpenAll.Count;
+                    int posCurr = tab.PositionsOpenAll.Count; 
+                    int posTotal = tab.PositionsAll.Count;  
 
                     if (tab.CandlesAll != null && tab.CandlesAll.Count != 0)
                     {
@@ -159,7 +160,7 @@ namespace OsEngine.OsTrader.Panels.Tab
                     row.Cells[3].Value = last.ToString();
                     row.Cells[4].Value = bid.ToString();
                     row.Cells[5].Value = ask.ToString();
-					row.Cells[6].Value = posCount.ToString();
+					row.Cells[6].Value = posCurr.ToString() + "/" + posTotal.ToString();
                 }
             }
             catch (Exception error)
@@ -1001,7 +1002,7 @@ namespace OsEngine.OsTrader.Panels.Tab
 
             DataGridViewColumn colum7 = new DataGridViewColumn();           
             colum7.CellTemplate = cell0;
-            colum7.HeaderText = "Pos. count";
+            colum7.HeaderText = "Pos. (curr/total)";
             colum7.ReadOnly = true;
             colum7.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
             newGrid.Columns.Add(colum7);


### PR DESCRIPTION
![532133213](https://user-images.githubusercontent.com/109503835/189642182-365539c8-b670-4840-b51f-0d845e5525e7.png)

Дополнение вывода в таблицу Скринера информации о позициях - добавление общего кол-ва позиций рядом с текущим.

Для чего - что бы можно было посмотреть какая вкладка сколько отторговала позиций и открыть интересующую ( что важно, без необходимости открывать Журнал) - это быстро и удобно.
Особенно актуально в Тестере, т.к. там обычно требуется общее кол-во для анализа.
