### PR TITLE
NullReferenceException в Spot.BinanceClient.GetNonce()

### DIFF
--- a/project/OsEngine/Market/Servers/Binance/Spot/BinanceClientSpot.cs
+++ b/project/OsEngine/Market/Servers/Binance/Spot/BinanceClientSpot.cs
@@ -909,14 +909,20 @@ namespace OsEngine.Market.Servers.Binance.Spot
         {
             var resTime = CreateQuery(BinanceExchangeType.SpotExchange, Method.GET, "api/v1/time", null, false);
             var result = JsonConvert.DeserializeAnonymousType(resTime, new BinanceTime());
-            return (result.serverTime + 500).ToString();
+            
+            if (result != null)
+            {
+                return (result.serverTime + 500).ToString();
+            }
+            else
+            {
+                DateTime yearBegin = new DateTime(1970, 1, 1);
+                var timeStamp = DateTime.UtcNow - yearBegin;
+                var r = timeStamp.TotalMilliseconds;
+                var re = Convert.ToInt64(r);
 
-            /*DateTime yearBegin = new DateTime(1970, 1, 1);
-            var res = DateTime.UtcNow;
-            var timeStamp = DateTime.UtcNow - yearBegin;
-            var r = timeStamp.TotalMilliseconds;
-            var re = Convert.ToInt64(r);
-            return re.ToString();*/
+                return re.ToString();
+            }
         }
 
         private string CreateSignature(string message)


### PR DESCRIPTION
Устранение эксепшена при торговле через BinanceSpot: 
System.NullReferenceException: Ссылка на объект не указывает на экземпляр объекта.
в OsEngine.Market.Servers.Binance.Spot.BinanceClient.GetNonce()
в OsEngine.Market.Servers.Binance.Spot.BinanceClient.CreateQuery(BinanceExchangeType startUri, Method method, String endpoint, Dictionary`2 param, Boolean auth)