### PR TITLE
Увеличение высоты окна Журнала

### DIFF
--- a/project/OsEngine/Journal/JournalUi.xaml
+++ b/project/OsEngine/Journal/JournalUi.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="OsEngine.Journal.JournalUi"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Journal" Height="780" Width="1350" MinWidth="400" MinHeight="300" Style="{StaticResource WindowStyleCanResize}" Icon="/Images/OsLogo.ico"  WindowStartupLocation="CenterScreen">
+        Title="Journal" Height="800" Width="1350" MinWidth="400" MinHeight="300" Style="{StaticResource WindowStyleCanResize}" Icon="/Images/OsLogo.ico"  WindowStartupLocation="CenterScreen">
     <Grid>
         <TabControl Grid.Row="0" x:Name="TabBots"  Margin="28,0,10,0" VerticalAlignment="Top">
             <TabItem Header="Empty" >


### PR DESCRIPTION
После добавления в Статистику **среднего времени удержания позиции** Объем комиссии съехал в невидимую сразу зону.
Увеличил высоту окна, чтобы вмещалось (чтобы не надо было скроллить или масштабировать окно). 