### PR TITLE
Контраст шорта на графике и увеличение дальности заброса рыночных заявок

### DIFF
--- a/project/OsEngine/Charts/CandleChart/WinFormsChartPainter.cs
+++ b/project/OsEngine/Charts/CandleChart/WinFormsChartPainter.cs
@@ -1746,7 +1746,7 @@ namespace OsEngine.Charts.CandleChart
                             }
                             else
                             {
-                                buySellSeries.Points[buySellSeries.Points.Count - 1].Color = Color.DarkRed;
+                                buySellSeries.Points[buySellSeries.Points.Count - 1].Color = Color.Fuchsia;
                             }
                         }
                     }

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabSimple.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabSimple.cs
@@ -1261,7 +1261,7 @@ namespace OsEngine.OsTrader.Panels.Tab
                     return null;
                 }
 
-                price = price + Securiti.PriceStep * 20;
+                price = price + Securiti.PriceStep * 40;
 
                 OrderPriceType type = OrderPriceType.Market;
 
@@ -1744,7 +1744,7 @@ namespace OsEngine.OsTrader.Panels.Tab
                     return null;
                 }
 
-                price = price - Securiti.PriceStep * 20;
+                price = price - Securiti.PriceStep * 40;
 
                 OrderPriceType type = OrderPriceType.Market;
 
@@ -2262,11 +2262,11 @@ namespace OsEngine.OsTrader.Panels.Tab
 
                 if (position.Direction == Side.Buy)
                 {
-                    price = _connector.BestBid - Securiti.PriceStep * 20;
+                    price = _connector.BestBid - Securiti.PriceStep * 40;
                 }
                 else
                 {
-                    price = price + Securiti.PriceStep * 20;
+                    price = price + Securiti.PriceStep * 40;
                 }
 
                 if (price == 0)


### PR DESCRIPTION
**Контраст шорта на графике:**
У маркера открытия шорта слабый контраст на графике, от чего он плохо различим на свечах, особенно падающих. Предлагаю изменить этот цвет на более контрастный. Выбирал из различных оттенков и, на мой взгляд, более всего подходящий (не путается с лонговыми цветами и отличается от закрытия шорта) цвет Fuchsia. На скрине этот цвет в сравнении с текущим:
![541516](https://user-images.githubusercontent.com/109503835/206837626-fde13b52-9708-4410-8c7a-e272b3d73ae9.jpg)

**Увеличение дальности заброса рыночных заявок:**
Текущая дальность заброса рыночных заявок составляет 20 тиков - это мало для некоторых инструментов. Например, на Биткоине 20 тиков это обычные колебания, шум - соответственно можно не войти/выйти, кидая с забросом 20.
![BTC](https://user-images.githubusercontent.com/109503835/206837757-a776231a-9f8d-40dd-89df-e77a7e780b9d.png)
В тоже время есть инструменты с очень крупными шагами цены. Например, на Бинанс есть инструменты с шагом около 0,2% - это накладывает ограничения на слишком дальний заброс заявок, потому что при забросе более чем на 10% от текущей цены, Бинанс отшибает такие заявки. Учитывая это, предлагаю компромиссный вариант - сделать 40 заброс вместо 20.