### PR TITLE
Позиционирование Журнала при открытии относительно OsEngine

### DIFF
--- a/project/OsEngine/Journal/JournalUi.xaml
+++ b/project/OsEngine/Journal/JournalUi.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="OsEngine.Journal.JournalUi"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Journal" Height="800" Width="1350" MinWidth="400" MinHeight="300" Style="{StaticResource WindowStyleCanResize}" Icon="/Images/OsLogo.ico"  WindowStartupLocation="CenterScreen">
+        Title="Journal" Height="800" Width="1350" MinWidth="400" MinHeight="300" Style="{StaticResource WindowStyleCanResize}" Icon="/Images/OsLogo.ico"  WindowStartupLocation="Manual">
     <Grid>
         <TabControl Grid.Row="0" x:Name="TabBots"  Margin="28,0,10,0" VerticalAlignment="Top">
             <TabItem Header="Empty" >

--- a/project/OsEngine/OsTrader/Gui/BotTabsPainter.cs
+++ b/project/OsEngine/OsTrader/Gui/BotTabsPainter.cs
@@ -179,7 +179,7 @@ colum09.HeaderText = "Action";           7
             if (coluIndex == 6 &&
      rowIndex == botsCount + 1)
             { // вызываем общий журнал
-                _master.ShowCommunityJournal(2);
+                _master.ShowCommunityJournal(2, 0, 0);
             }
             else if (coluIndex == 7 &&
     rowIndex == botsCount + 1)

--- a/project/OsEngine/OsTrader/Gui/RobotUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Gui/RobotUi.xaml.cs
@@ -275,7 +275,7 @@ namespace OsEngine.OsTrader.Gui
 
         private void ButtonJournalCommunity_Click(object sender, RoutedEventArgs e)
         {
-            _strategyKeeper.ShowCommunityJournal(1);
+            _strategyKeeper.ShowCommunityJournal(1, Top + ButtonJournalCommunity.ActualHeight, Left + ButtonJournalCommunity.ActualHeight);
         }
 
         private void ButtonRedactTab_Click(object sender, RoutedEventArgs e)

--- a/project/OsEngine/OsTrader/Gui/TesterUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Gui/TesterUi.xaml.cs
@@ -249,7 +249,7 @@ namespace OsEngine.OsTrader.Gui
 
         private void ButtonJournalCommunity_Click(object sender, RoutedEventArgs e)
         {
-            _strategyKeeper.ShowCommunityJournal(1);
+            _strategyKeeper.ShowCommunityJournal(1, Top + ButtonJournalCommunity.ActualHeight, Left + ButtonJournalCommunity.ActualHeight);
         }
 
         private void ButtonRedactTab_Click(object sender, RoutedEventArgs e)

--- a/project/OsEngine/OsTrader/OsTraderMaster.cs
+++ b/project/OsEngine/OsTrader/OsTraderMaster.cs
@@ -624,7 +624,7 @@ namespace OsEngine.OsTrader
         /// show journal for all robots
         /// показать журнал по всем роботам
         /// </summary>
-        public void ShowCommunityJournal(int journalVersion)
+        public void ShowCommunityJournal(int journalVersion, double top, double left)
         {
             try
             {
@@ -678,6 +678,17 @@ namespace OsEngine.OsTrader
                     _journalUi2 = new JournalUi2(panelsJournal, _startProgram);
                     _journalUi2.LogMessageEvent += SendNewLogMessage;
                     _journalUi2.Closed += _journalUi_Closed;
+
+                    if (top != 0 && left != 0)
+                    {
+                        _journalUi2.Top = top;
+                        _journalUi2.Left = left;
+                    }
+                    else
+                    {
+                        _journalUi2.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    }
+
                     _journalUi2.Show();
                 }
                 if (journalVersion == 1)
@@ -685,6 +696,17 @@ namespace OsEngine.OsTrader
                     _journalUi1 = new JournalUi(panelsJournal, _startProgram);
                     _journalUi1.LogMessageEvent += SendNewLogMessage;
                     _journalUi1.Closed += _journalUi_Closed;
+
+                    if (top != 0 && left != 0)
+                    {
+                        _journalUi1.Top = top;
+                        _journalUi1.Left = left;
+                    }
+                    else
+                    {
+                        _journalUi1.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    }
+                                
                     _journalUi1.Show();
                 }
             }


### PR DESCRIPTION
Журнал открывается с небольшим смещением относительно основного окна OsEngine:
![52122123](https://user-images.githubusercontent.com/109503835/209574652-955d8e8b-eace-4baa-bb54-a473467f1b78.png)
