### PR TITLE
Открытие окна настроек параметров у курсора

### DIFF
--- a/project/OsEngine/OsTrader/Panels/BotPanel.cs
+++ b/project/OsEngine/OsTrader/Panels/BotPanel.cs
@@ -739,6 +739,8 @@ position => position.State != PositionStateType.OpeningFail
             if (_paramUi == null)
             {
                 _paramUi = new ParemetrsUi(_parameters, ParamGuiSettings);
+				_paramUi.Left = System.Windows.Forms.Cursor.Position.X - Convert.ToDouble(ParamGuiSettings.Width);
+                _paramUi.Top = System.Windows.Forms.Cursor.Position.Y;
                 _paramUi.Show();
                 _paramUi.Closing += _paramUi_Closing;
             }


### PR DESCRIPTION
Часто используемое окно удобно когда открывается у курсора:
![5521231313](https://user-images.githubusercontent.com/109503835/212484349-e2758e3d-dfdc-49c8-9992-dd7f59a0e301.png)
