### PR TITLE
Доработка открытия вспомогательных окон

### DIFF
--- a/project/OsEngine/Alerts/AlertToChartCreateUi.xaml.cs
+++ b/project/OsEngine/Alerts/AlertToChartCreateUi.xaml.cs
@@ -31,7 +31,7 @@ namespace OsEngine.Alerts
         public AlertToChartCreateUi(AlertToChart alert, AlertMaster keeper) 
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _waitOne = false;
             _waitTwo = false;
             NeadToSave = false;

--- a/project/OsEngine/Alerts/AlertToPriceCreateUi.xaml.cs
+++ b/project/OsEngine/Alerts/AlertToPriceCreateUi.xaml.cs
@@ -20,7 +20,7 @@ namespace OsEngine.Alerts
         public AlertToPriceCreateUi(AlertToPrice alert)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             MyAlert = alert;
 
             CheckBoxOnOff.IsChecked = MyAlert.IsOn;

--- a/project/OsEngine/Charts/CandleChart/Indicators/AcUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AcUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AcUi(Ac ac)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _ac = ac;
 
             TextBoxLenght.Text = _ac.LenghtLong.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/AccumulationDistributionUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AccumulationDistributionUi.xaml.cs
@@ -33,7 +33,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AccumulationDistributionUi(AccumulationDistribution ad)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _ad = ad;
 
 

--- a/project/OsEngine/Charts/CandleChart/Indicators/AdaptiveLookBackUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AdaptiveLookBackUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AdaptiveLookBackUi(AdaptiveLookBack alb)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _alb = alb;
 
             TextBoxLenght.Text = _alb.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/AdxUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AdxUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AdxUi(Adx adx) 
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _adx = adx;
 
             TextBoxLenght.Text = _adx.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/AlligatorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AlligatorUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AlligatorUi(Alligator alligator)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _alligator = alligator;
 
             TextBoxLenghtBase.Text = _alligator.LenghtBase.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/AtrChannelUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AtrChannelUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AtrChannelUi(AtrChannel atr)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _atr = atr;
 
             TextBoxLenght.Text = _atr.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/AtrUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AtrUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AtrUi(Atr atr)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _atr = atr;
 
             TextBoxLenght.Text = _atr.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/AwesomeOscillatorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/AwesomeOscillatorUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public AwesomeOscillatorUi(AwesomeOscillator awesomeOscillator)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _awesomeOscillatoro = awesomeOscillator;
 
             TextBoxLenghtLong.Text = _awesomeOscillatoro.LenghtLong.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/BearsPowerUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/BearsPowerUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public BearsPowerUi(BearsPower bp)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _bp = bp;
 
             TextBoxLenght.Text = _bp.Period.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/BfMfiUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/BfMfiUi.xaml.cs
@@ -20,7 +20,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public BfMfiUi(BfMfi mfi) //constructor/конструктор
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mfi = mfi;
             ShowSettingsOnForm();
 

--- a/project/OsEngine/Charts/CandleChart/Indicators/BollingerUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/BollingerUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public BollingerUi(Bollinger bollinger)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _bollinger = bollinger;
 
             TextBoxDeviation.Text = _bollinger.Deviation.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/BullsPowerUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/BullsPowerUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public BullsPowerUi(BullsPower bp)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _bp = bp;
 
             TextBoxLenght.Text = _bp.Period.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/CCIUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/CCIUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public CciUi(Cci mA)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mA = mA;
 
             TextBoxLenght.Text = _mA.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/CmoUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/CmoUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public CmoUi(Cmo cmo)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _cmo = cmo;
             TextBoxLenght.Text = _cmo.Period.ToString();
 

--- a/project/OsEngine/Charts/CandleChart/Indicators/DonchianChannelUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/DonchianChannelUi.xaml.cs
@@ -32,7 +32,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public DonchianChannelUi(DonchianChannel donchian)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _donchian = donchian;
 
             TextBoxLenght.Text = _donchian.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/DynamicTrendDetectorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/DynamicTrendDetectorUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public DynamicTrendDetectorUi(DynamicTrendDetector dtd)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _dtd = dtd;
 
             TextBoxLenght.Text = _dtd.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/EfficiencyRatioUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/EfficiencyRatioUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public EfficiencyRatioUi(EfficiencyRatio eR)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _eR = eR;
 
             TextBoxLenght.Text = _eR.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/EnvelopsUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/EnvelopsUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public EnvelopsUi(Envelops envelops)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _envelops = envelops;
 
             HostColorUp.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/ForceIndexUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/ForceIndexUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public ForceIndexUi(ForceIndex forceindex)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _forceindex = forceindex;
 
             TextBoxLenght.Text = _forceindex.Period.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/FractalUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/FractalUi.xaml.cs
@@ -35,7 +35,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public FractalUi(Fractal fractail) 
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _fractail = fractail;
 
             HostColorUp.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/IndicarotCreateUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/IndicarotCreateUi.xaml.cs
@@ -47,7 +47,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public IndicarotCreateUi(ChartCandleMaster chartMaster)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _chartMaster = chartMaster;
 
             _gridViewIndicators = DataGridFactory.GetDataGridView(DataGridViewSelectionMode.FullRowSelect,

--- a/project/OsEngine/Charts/CandleChart/Indicators/IshimokuUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/IshimokuUi.xaml.cs
@@ -40,7 +40,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public IshimokuUi(Ichimoku ishimoku)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _ishimoku = ishimoku;
 
             TextBoxPeriodOne.Text = _ishimoku.LenghtFirst.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/IvashovRangeUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/IvashovRangeUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public IvashovRangeUi(IvashovRange ir)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _ir = ir;
 
             TextBoxLenght.Text = _ir.LenghtMa.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/KalmanFilterUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/KalmanFilterUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public KalmanFilterUi(KalmanFilter indicator)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _indicator = indicator;
 
             TextBoxSharpness.Text = _indicator.Sharpness.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/LinearRegressionCurveUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/LinearRegressionCurveUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public LinearRegressionCurveUi(LinearRegressionCurve linregc)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _lrc = linregc;
 
             TextBoxLenght.Text = _lrc.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/MacdHistogramUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/MacdHistogramUi.xaml.cs
@@ -35,7 +35,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public MacdHistogramUi(MacdHistogram macd)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _macd = macd;
 
             HostColorUp.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/MacdLineUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/MacdLineUi.xaml.cs
@@ -35,7 +35,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public MacdLineUi(MacdLine macd)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _macd = macd;
 
             HostColorUp.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/MomentumUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/MomentumUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public MomentumUi(Momentum momentum)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _momentum = momentum;
 
             TextBoxLenght.Text = _momentum.Nperiod.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/MoneyFlowIndexUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/MoneyFlowIndexUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public MoneyFlowIndexUi(MoneyFlowIndex mfi)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mfi = mfi;
 
             TextBoxLenght.Text = _mfi.Nperiod.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/MovingAverageUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/MovingAverageUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public MovingAverageUi(MovingAverage mA)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mA = mA;
 
             TextBoxLenght.Text = _mA.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/OnBalanceVolumeUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/OnBalanceVolumeUi.xaml.cs
@@ -36,7 +36,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public OnBalanceVolumeUi(OnBalanceVolume obv)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _obv = obv;
 
             HostColorBase.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/ParabolicSARUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/ParabolicSARUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public ParabolicSarUi(ParabolicSaR mA)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mA = mA;
 
             TextBoxAf.Text = _mA.Af.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/PivotPointsUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/PivotPointsUi.xaml.cs
@@ -27,7 +27,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public PivotPointsUi(PivotPoints pivotPoints)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _pivotPoints = pivotPoints;
 
             CheckBoxPaintOnOff.IsChecked = _pivotPoints.PaintOn;

--- a/project/OsEngine/Charts/CandleChart/Indicators/PivotUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/PivotUi.xaml.cs
@@ -36,7 +36,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public PivotUi(Pivot pivot)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _pivot = pivot;
 
 

--- a/project/OsEngine/Charts/CandleChart/Indicators/PriceChannelUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/PriceChannelUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public PriceChannelUi(PriceChannel bollinger)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _bollinger = bollinger;
 
             TextBoxLenghtUp.Text = _bollinger.LenghtUpLine.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/PriceOscillatorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/PriceOscillatorUi.xaml.cs
@@ -36,7 +36,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public PriceOscillatorUi(PriceOscillator pO)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _pO = pO;
 
             HostColorBase.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/RocUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/RocUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public RocUi(Roc roc)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _roc = roc;
 
             TextBoxLenght.Text = _roc.Period.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/RsiUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/RsiUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public RsiUi(Rsi rsi)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _rsi = rsi;
 
             TextBoxLenght.Text = _rsi.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/RviUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/RviUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public RviUi(Rvi rvi)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _rvi = rvi;
 
             TextBoxLenght.Text = _rvi.Period.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/SimpleVWAPUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/SimpleVWAPUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public SimpleVWAPUi(SimpleVWAP vwap)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _vwap = vwap;
 
             HostColor.Child = new TextBox();

--- a/project/OsEngine/Charts/CandleChart/Indicators/StandardDeviationUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/StandardDeviationUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public StandardDeviationUi(StandardDeviation mA)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mA = mA;
 
             TextBoxLenght.Text = _mA.Lenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/StochRsiUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/StochRsiUi.xaml.cs
@@ -36,7 +36,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public StochRsiUi(StochRsi rsi)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _rsi = rsi;
 
             TextBoxLenght.Text = _rsi.RsiLenght.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/StochasticOscillatorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/StochasticOscillatorUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public StochasticOscillatorUi(StochasticOscillator so)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _so = so;
 
             TextBoxLenght.Text = _so.P1.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/TickVolumeUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/TickVolumeUi.xaml.cs
@@ -20,7 +20,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public TickVolumeUi(TickVolume volume) // constructor//конструктор
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _volume = volume;
             ShowSettingsOnForm();
 

--- a/project/OsEngine/Charts/CandleChart/Indicators/TrixUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/TrixUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public TrixUi(Trix trix)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _trix = trix;
 
             TextBoxLenght.Text = _trix.Period.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/UltimateOscillatorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/UltimateOscillatorUi.xaml.cs
@@ -37,7 +37,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public UltimateOscillatorUi(UltimateOscillator indicator)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _indicator = indicator;
 
             TextBoxLenght.Text = _indicator.Period1.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/VerticalHorizontalFilterUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/VerticalHorizontalFilterUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public VerticalHorizontalFilterUi(VerticalHorizontalFilter vhf)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _vhf = vhf;
 
             TextBoxLenght.Text = _vhf.Nperiod.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/VolumeOscillatorUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/VolumeOscillatorUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public VolumeOscillatorUi(VolumeOscillator mA)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _mA = mA;
 
             TextBoxLenght1.Text = _mA.Lenght1.ToString();

--- a/project/OsEngine/Charts/CandleChart/Indicators/VolumeUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/VolumeUi.xaml.cs
@@ -20,7 +20,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
       public VolumeUi(Volume fractail) // constructor//конструктор
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _volume = fractail;
             ShowSettingsOnForm();
 

--- a/project/OsEngine/Charts/CandleChart/Indicators/VwapUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/VwapUi.xaml.cs
@@ -22,7 +22,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public VwapUi(Vwap indicator)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _indicator = indicator;
 
             UseDate.IsChecked = _indicator.UseDate;

--- a/project/OsEngine/Charts/CandleChart/Indicators/WilliamsRangeUi.xaml.cs
+++ b/project/OsEngine/Charts/CandleChart/Indicators/WilliamsRangeUi.xaml.cs
@@ -38,7 +38,7 @@ namespace OsEngine.Charts.CandleChart.Indicators
         public WilliamsRangeUi(WilliamsRange wr)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _wr = wr;
 
             TextBoxLenght.Text = _wr.Nperiod.ToString();

--- a/project/OsEngine/Entity/AcceptDialogUi.xaml.cs
+++ b/project/OsEngine/Entity/AcceptDialogUi.xaml.cs
@@ -31,7 +31,7 @@ namespace OsEngine.Entity
         public AcceptDialogUi(string text)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             LabelText.Content = text;
 
             _numMessage++;

--- a/project/OsEngine/Entity/DateTimeSelectionDialog.xaml.cs
+++ b/project/OsEngine/Entity/DateTimeSelectionDialog.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Entity
         public DateTimeSelectionDialog(DateTime initTime)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             Time = initTime;
 
             DateTimePicker.SelectedDate = Time;

--- a/project/OsEngine/Entity/PositionUi.xaml.cs
+++ b/project/OsEngine/Entity/PositionUi.xaml.cs
@@ -35,7 +35,7 @@ namespace OsEngine.Entity
             _startProgramm = startProgram;
             _position = position;
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             CreateMainTable();
             CreateOrdersTable();
             CreateTradeTable();

--- a/project/OsEngine/Entity/ProxyHolderAddUi.xaml.cs
+++ b/project/OsEngine/Entity/ProxyHolderAddUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Entity
         public ProxyHolderAddUi()
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             this.Activate();
             this.Focus();
         }

--- a/project/OsEngine/Entity/SecuritiesUi.xaml.cs
+++ b/project/OsEngine/Entity/SecuritiesUi.xaml.cs
@@ -26,7 +26,7 @@ namespace OsEngine.Entity
         public SecuritiesUi(IServer server)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             CreateTable();
             PaintSecurities(server.Securities);
             server.SecuritiesChangeEvent += _server_SecuritiesChangeEvent;

--- a/project/OsEngine/Entity/SecurityUi.xaml.cs
+++ b/project/OsEngine/Entity/SecurityUi.xaml.cs
@@ -32,7 +32,7 @@ namespace OsEngine.Entity
         {
             _security = security;
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             CultureInfo culture = new CultureInfo("ru-RU");
 

--- a/project/OsEngine/Entity/StrategyParemetrsUi.xaml.cs
+++ b/project/OsEngine/Entity/StrategyParemetrsUi.xaml.cs
@@ -24,7 +24,7 @@ namespace OsEngine.Entity
         public ParemetrsUi(List<IIStrategyParameter> parameters, ParamGuiSettings settings)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             Height = (double)settings.Height;
             Width = (double)settings.Width;

--- a/project/OsEngine/Indicators/AIndicatorUi.xaml.cs
+++ b/project/OsEngine/Indicators/AIndicatorUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Indicators
         public AIndicatorUi(Aindicator indicator)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             Title = indicator.GetType().Name + " " + OsLocalization.Charts.Label1;
             _indicator = indicator;
 

--- a/project/OsEngine/Journal/NewGroupAddInJournalUi.xaml.cs
+++ b/project/OsEngine/Journal/NewGroupAddInJournalUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Journal
         public NewGroupAddInJournalUi(List<string> oldGroupNames)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _oldGroupNames = oldGroupNames;
             Title = OsLocalization.Journal.Label13;
             ButtonAccept.Content = OsLocalization.Journal.Label14;

--- a/project/OsEngine/Layout/StartupLocation.cs
+++ b/project/OsEngine/Layout/StartupLocation.cs
@@ -34,7 +34,7 @@ namespace OsEngine.Layout
             double xPosByWin32 = MouseCoordinates.XmousePos(ui);
             double yPosByWin32 = MouseCoordinates.YmousePos(ui);
 
-            ui.Left = xPosByWin32;
+            ui.Left = xPosByWin32 - ui.ActualWidth;
             ui.Top = yPosByWin32;
 
             ui.Activated -= Ui_Start_MouseInCentre_ContentActivated;
@@ -64,7 +64,7 @@ namespace OsEngine.Layout
             double xPosByWin32 = MouseCoordinates.XmousePos(ui);
             double yPosByWin32 = MouseCoordinates.YmousePos(ui);
 
-            double leftPos = xPosByWin32 - ui.Width / 2;
+            double leftPos = xPosByWin32 - ui.Width;
             double topPos = yPosByWin32 - ui.Height / 2;
 
             if(leftPos < 0)

--- a/project/OsEngine/Logging/MessageSenderUi.xaml.cs
+++ b/project/OsEngine/Logging/MessageSenderUi.xaml.cs
@@ -24,7 +24,7 @@ namespace OsEngine.Logging
         {
             _sender = sender;
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             LoadDateOnForm();
 
             Title = OsLocalization.Logging.TitleMessageSenderUi;

--- a/project/OsEngine/Logging/ServerMailUi.xaml.cs
+++ b/project/OsEngine/Logging/ServerMailUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Logging
          public ServerMailDeliveryUi() // constructor / конструктор
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             ServerMail serverMail = ServerMail.GetServer();
 

--- a/project/OsEngine/Logging/ServerSmsUi.xaml.cs
+++ b/project/OsEngine/Logging/ServerSmsUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Logging
         public ServerSmsUi() // constructor / конструктор
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             ServerSms serverSms = ServerSms.GetSmsServer();
 
             TextBoxMyLogin.Text = serverSms.SmscLogin;

--- a/project/OsEngine/Logging/ServerWebhookUi.xaml.cs
+++ b/project/OsEngine/Logging/ServerWebhookUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Logging
          public ServerWebhookDeliveryUi() // constructor / конструктор
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             ServerWebhook serverWebhook = ServerWebhook.GetServer();
 

--- a/project/OsEngine/Market/ServerMasterUi.xaml.cs
+++ b/project/OsEngine/Market/ServerMasterUi.xaml.cs
@@ -24,7 +24,7 @@ namespace OsEngine.Market
         public ServerMasterUi(bool isTester)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             List<IServer> servers = ServerMaster.GetServers();
 

--- a/project/OsEngine/Market/Servers/AServerParameterUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/AServerParameterUi.xaml.cs
@@ -25,7 +25,7 @@ namespace OsEngine.Market.Servers
         public AServerParameterUi(AServer server)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _server = server;
 
             _server.Log.StartPaint(HostLog);

--- a/project/OsEngine/Market/Servers/AstsBridge/AstsServerUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/AstsBridge/AstsServerUi.xaml.cs
@@ -21,7 +21,7 @@ namespace OsEngine.Market.Servers.AstsBridge
         public AstsServerUi(AstsBridgeServer server, Log log)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _server = server;
 
             TextBoxServerAdress.Text = _server.ServerAdress;

--- a/project/OsEngine/Market/Servers/Finam/FinamServerUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/Finam/FinamServerUi.xaml.cs
@@ -20,7 +20,7 @@ namespace OsEngine.Market.Servers.Finam
         public FinamServerUi(FinamServer server, Log log)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _server = server;
 
             TextBoxServerAdress.Text = _server.ServerAdress;

--- a/project/OsEngine/Market/Servers/InteractiveBrokers/IbContractStorageUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/InteractiveBrokers/IbContractStorageUi.xaml.cs
@@ -28,7 +28,7 @@ namespace OsEngine.Market.Servers.InteractiveBrokers
         public IbContractStorageUi(List<SecurityIb> secToSubscrible, InteractiveBrokersServerRealization server)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             SecToSubscrible = secToSubscrible;
             _server = server;
 

--- a/project/OsEngine/Market/Servers/SmartCom/SmartComServerUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/SmartCom/SmartComServerUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Market.Servers.SmartCom
         public SmartComServerUi(SmartComServer server, Log log)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _server = server;
 
             TextBoxServerAdress.Text = _server.ServerAdress;

--- a/project/OsEngine/Market/Servers/Tester/GoToUi.xaml.cs
+++ b/project/OsEngine/Market/Servers/Tester/GoToUi.xaml.cs
@@ -25,7 +25,7 @@ namespace OsEngine.Market.Servers.Tester
         public GoToUi(DateTime timeStart, DateTime timeEnd, DateTime timeNow)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             if ((timeEnd - timeStart).TotalDays <= 0)
             {

--- a/project/OsEngine/Market/Servers/Transaq/ChangeTransaqPassword.xaml.cs
+++ b/project/OsEngine/Market/Servers/Transaq/ChangeTransaqPassword.xaml.cs
@@ -14,7 +14,7 @@ namespace OsEngine.Market.Servers.Transaq
         public ChangeTransaqPassword(string message, TransaqServerRealization server)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _server = server;
             TextInfo.Text = message;
 

--- a/project/OsEngine/OsData/NewSecurityUi.xaml.cs
+++ b/project/OsEngine/OsData/NewSecurityUi.xaml.cs
@@ -40,7 +40,7 @@ namespace OsEngine.OsData
         public NewSecurityUi(List<Security> securities)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _securities = securities;
 
             GetClasses();

--- a/project/OsEngine/OsMiner/OsMinerSetUi.xaml.cs
+++ b/project/OsEngine/OsMiner/OsMinerSetUi.xaml.cs
@@ -12,7 +12,7 @@ namespace OsEngine.OsMiner
         public OsMinerSetUi(int numSet, OsMinerSet set)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _set = set;
 
             if (string.IsNullOrEmpty(_set.Name))

--- a/project/OsEngine/OsMiner/Patterns/AutoTestResultsUi.xaml.cs
+++ b/project/OsEngine/OsMiner/Patterns/AutoTestResultsUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.OsMiner.Patterns
         public AutoTestResultsUi(List<TestResult> testResults)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _testResults = testResults;
             _grid = new DataGridView();
             CreateGridPatternsGrid(_grid, Host);

--- a/project/OsEngine/OsMiner/Patterns/PatternsCreateUi.xaml.cs
+++ b/project/OsEngine/OsMiner/Patterns/PatternsCreateUi.xaml.cs
@@ -13,7 +13,7 @@ namespace OsEngine.OsMiner.Patterns
         public PatternsCreateUi(int patternNum)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             TextBoxPatternName.Text = OsLocalization.Miner.Label25 + patternNum;
             Title = OsLocalization.Miner.Label26;

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabClusterUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabClusterUi.xaml.cs
@@ -19,7 +19,7 @@ namespace OsEngine.OsTrader.Panels.Tab
         public BotTabClusterUi(BotTabCluster tab)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _tab = tab;
 
             TextBoxStep.Text = _tab.LineStep.ToString();

--- a/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionCloseUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionCloseUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.OsTrader.Panels.Tab.Internal
         {
 
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             TextBoxPrice.Text = lastSecurityPrice.ToStringWithNoEndZero();
             TextBoxSecurity.Text = position.OpenOrders[0].SecurityNameCode;

--- a/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionModificateUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionModificateUi.xaml.cs
@@ -16,7 +16,7 @@ namespace OsEngine.OsTrader.Panels.Tab.Internal
         public PositionModificateUi(decimal lastPrice, string nameSecurity)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             ComboBoxSide.Items.Add(Side.Buy);
             ComboBoxSide.Items.Add(Side.Sell);

--- a/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionOpenUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionOpenUi.xaml.cs
@@ -16,7 +16,7 @@ namespace OsEngine.OsTrader.Panels.Tab.Internal
         public PositionOpenUi(decimal lastPrice, string nameSecurity)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             ComboBoxSide.Items.Add(Side.Buy);
             ComboBoxSide.Items.Add(Side.Sell);

--- a/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionStopUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionStopUi.xaml.cs
@@ -16,7 +16,7 @@ namespace OsEngine.OsTrader.Panels.Tab.Internal
         public PositionStopUi(Position position, decimal lastSecurityPrice, string title)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             Title = title;
 
             TextBoxPriceOrder.Text = lastSecurityPrice.ToStringWithNoEndZero();

--- a/project/OsEngine/OsTrader/RiskManager/RiskManagerUi.xaml.cs
+++ b/project/OsEngine/OsTrader/RiskManager/RiskManagerUi.xaml.cs
@@ -27,7 +27,7 @@ namespace OsEngine.OsTrader.RiskManager
             {
                 _riskManager = riskManager;
                 InitializeComponent();
-                OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+                OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
                 LoadDateOnForm();
             }
             catch (Exception error)

--- a/project/OsEngine/Robots/BotCreateUi.xaml.cs
+++ b/project/OsEngine/Robots/BotCreateUi.xaml.cs
@@ -20,7 +20,7 @@ namespace OsEngine.Robots
         public BotCreateUi(List<string> botsIncluded, List<string> botsFromScript, StartProgram startProgram)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
 
             for (int i = 0;i < botsIncluded.Count;i++)
             {

--- a/project/OsEngine/Robots/CounterTrend/RsiContrtrendUi.xaml.cs
+++ b/project/OsEngine/Robots/CounterTrend/RsiContrtrendUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Robots.CounterTrend
         public RsiContrtrendUi(RsiContrtrend strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             ComboBoxRegime.Items.Add(BotTradeRegime.Off);

--- a/project/OsEngine/Robots/CounterTrend/StrategyBollingerUi.xaml.cs
+++ b/project/OsEngine/Robots/CounterTrend/StrategyBollingerUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.CounterTrend
         public StrategyBollingerUi(StrategyBollinger strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.Volume.ToString();

--- a/project/OsEngine/Robots/CounterTrend/WilliamsRangeTradeUi.xaml.cs
+++ b/project/OsEngine/Robots/CounterTrend/WilliamsRangeTradeUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.CounterTrend
         public WilliamsRangeTradeUi(WilliamsRangeTrade strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();

--- a/project/OsEngine/Robots/MarketMaker/MarketMakerBotUi.xaml.cs
+++ b/project/OsEngine/Robots/MarketMaker/MarketMakerBotUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.MarketMaker
         public MarketMakerBotUi(MarketMakerBot strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             ComboBoxRegime.Items.Add(BotTradeRegime.Off);

--- a/project/OsEngine/Robots/MarketMaker/PairTraderSimpleUi.xaml.cs
+++ b/project/OsEngine/Robots/MarketMaker/PairTraderSimpleUi.xaml.cs
@@ -16,7 +16,7 @@ namespace OsEngine.Robots.MarketMaker
         public PairTraderSimpleUi(PairTraderSimple strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             CultureInfo culture = new CultureInfo("ru-RU");

--- a/project/OsEngine/Robots/MarketMaker/PairTraderSpreadSmaUi.xaml.cs
+++ b/project/OsEngine/Robots/MarketMaker/PairTraderSpreadSmaUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.MarketMaker
          public PairTraderSpreadSmaUi(PairTraderSpreadSma strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             CultureInfo culture = new CultureInfo("ru-RU");

--- a/project/OsEngine/Robots/Patterns/PinBarTradeUi.xaml.cs
+++ b/project/OsEngine/Robots/Patterns/PinBarTradeUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Robots.Patterns
         public PinBarTradeUi(PinBarTrade strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();

--- a/project/OsEngine/Robots/Patterns/PivotPointsRobotUi.xaml.cs
+++ b/project/OsEngine/Robots/Patterns/PivotPointsRobotUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.Patterns
         public PivotPointsRobotUi(PivotPointsRobot strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();

--- a/project/OsEngine/Robots/Patterns/ThreeSoldierUi.xaml.cs
+++ b/project/OsEngine/Robots/Patterns/ThreeSoldierUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.Patterns
         public ThreeSoldierUi(ThreeSoldier strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             ComboBoxRegime.Items.Add(BotTradeRegime.Off);

--- a/project/OsEngine/Robots/Trend/MomentumMacdUi.xaml.cs
+++ b/project/OsEngine/Robots/Trend/MomentumMacdUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Robots.Trend
         public MomentumMacdUi(MomentumMacd strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();

--- a/project/OsEngine/Robots/Trend/ParabolicSarTradeUi.xaml.cs
+++ b/project/OsEngine/Robots/Trend/ParabolicSarTradeUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Robots.Trend
         public ParabolicSarTradeUi(ParabolicSarTrade strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();

--- a/project/OsEngine/Robots/Trend/PriceChannelTradeUi.xaml.cs
+++ b/project/OsEngine/Robots/Trend/PriceChannelTradeUi.xaml.cs
@@ -18,7 +18,7 @@ namespace OsEngine.Robots.Trend
         public PriceChannelTradeUi(PriceChannelTrade strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();

--- a/project/OsEngine/Robots/Trend/SmaStochasticUi.xaml.cs
+++ b/project/OsEngine/Robots/Trend/SmaStochasticUi.xaml.cs
@@ -17,7 +17,7 @@ namespace OsEngine.Robots.Trend
         public SmaStochasticUi(SmaStochastic strategy)
         {
             InitializeComponent();
-            OsEngine.Layout.StartupLocation.Start_MouseInCentre(this);
+            OsEngine.Layout.StartupLocation.Start_MouseInCorner(this);
             _strategy = strategy;
 
             TextBoxVolumeOne.Text = _strategy.VolumeFix.ToString();


### PR DESCRIPTION
Так как всё управление находится в основном справа, вспомогательные окна открывались выпадая вправо и/или вверх за экран (особенно на развернутой OsEngine на весь экран). 

Поэтому сделал открытие окон не ориентируясь центром на курсор, а слева от курсора. 
Некоторые окна (маленькие) открываются правым верхним углом, где крестик закрытия, у курсора - так удобнее (открыл, посмотрел, закрыл тут же не двигая далеко курсор). Большие окна серединой у курсора слева открываются (потому что из-за размера могут выпасть вниз за экран).