### PR TITLE
Подсветка строки с ботом в лайт-интерфейсе

### DIFF
--- a/project/OsEngine/OsTrader/Gui/BotTabsPainter.cs
+++ b/project/OsEngine/OsTrader/Gui/BotTabsPainter.cs
@@ -153,7 +153,26 @@ namespace OsEngine.OsTrader.Gui
             }
             int coluIndex = _grid.SelectedCells[0].ColumnIndex;
 
-            int rowIndex = _grid.SelectedCells[0].RowIndex;
+            int rowIndex = _grid.SelectedCells[0].RowIndex
+			
+			
+			for (int i = 0; i < _grid.RowCount; i++)
+            {
+                if (i == rowIndex)
+                {
+                    for (int y = 0; y < _grid.ColumnCount; y++)
+                    {
+                        _grid.Rows[rowIndex].Cells[y].Style.ForeColor = System.Drawing.Color.Cyan;
+                    }
+                }
+                else
+                {
+                    for (int y = 0; y < _grid.ColumnCount; y++)
+                    {
+                        _grid.Rows[i].Cells[y].Style.ForeColor = System.Drawing.Color.FromArgb(255, 255, 255);
+                    }
+                }
+            }
 
             /*
 colum0.HeaderText = "Num";


### PR DESCRIPTION
Текст строки с роботом в облегченном интерфейсе подсвечивается другим цветом при клике на ней - для того что бы видеть с каким роботом выполнялись действия в предыдущий раз:
![01421220](https://user-images.githubusercontent.com/109503835/215332620-2eb6a492-acce-4c2c-a080-a8482eeef1a9.png)
