### PR TITLE
Добавление кол-ва всех позиций в таблицу в лайт-интерфейс

### DIFF
--- a/project/OsEngine/Language/TraderLocal.cs
+++ b/project/OsEngine/Language/TraderLocal.cs
@@ -752,5 +752,9 @@ namespace OsEngine.Language
         public string Label185 => OsLocalization.ConvertToLocString(
               "Eng: Emulator on/off_" +
               "Ru: Эмулятор вкл/выкл_");
+
+        public string Label186 => OsLocalization.ConvertToLocString(
+              "Eng:Pos. (curr/total)_" +
+              "Ru:Поз. (откр/всего)_");			  
     }
 }

--- a/project/OsEngine/OsTrader/Gui/BotTabsPainter.cs
+++ b/project/OsEngine/OsTrader/Gui/BotTabsPainter.cs
@@ -87,7 +87,7 @@ namespace OsEngine.OsTrader.Gui
 
             DataGridViewColumn colum05 = new DataGridViewColumn();
             colum05.CellTemplate = cell0;
-            colum05.HeaderText = OsLocalization.Trader.Label20;//"Position";
+            colum05.HeaderText = OsLocalization.Trader.Label186;//"Position";
             colum05.ReadOnly = true;
             colum05.Width = 120;
             newGrid.Columns.Add(colum05);
@@ -404,7 +404,7 @@ colum10.HeaderText = "Action";
             }
 
             row.Cells.Add(new DataGridViewTextBoxCell());
-            row.Cells[4].Value = bot.PositionsCount;
+            row.Cells[4].Value = bot.PositionsCount.ToString() + "/" + bot.AllPositionsCount.ToString();
 
             row.Cells.Add(new DataGridViewCheckBoxCell());
             row.Cells[5].Value = bot.OnOffEventsInTabs;
@@ -546,11 +546,9 @@ colum9.HeaderText = "Journal";
                         }
                     }
 
-                    if(row.Cells[4].Value == null ||
-                        (row.Cells[4].Value != null 
-                        && row.Cells[4].Value.ToString() != bot.PositionsCount.ToString()))
+                    if (row.Cells[4].Value == null || (row.Cells[4].Value != null && row.Cells[4].Value.ToString() != bot.PositionsCount.ToString() + "/" + bot.AllPositionsCount.ToString()))
                     {
-                        row.Cells[4].Value = bot.PositionsCount;
+                        row.Cells[4].Value = bot.PositionsCount.ToString() + "/" + bot.AllPositionsCount.ToString();
                     }
 
                     if (row.Cells[5].Value == null ||

--- a/project/OsEngine/OsTrader/Panels/BotPanel.cs
+++ b/project/OsEngine/OsTrader/Panels/BotPanel.cs
@@ -721,6 +721,35 @@ position => position.State != PositionStateType.OpeningFail
             }
         }
 
+        /// <summary>
+        /// the number of all positions at the tabs of the robot / 
+        /// количество всех позиций у вкладок робота
+        /// </summary>
+        public int AllPositionsCount
+        {
+            get
+            {
+                List<Journal.Journal> journals = GetJournals();
+
+                if (journals == null || journals.Count == 0)
+                {
+                    return 0;
+                }
+
+                List<Position> pos = new List<Position>();
+
+                for (int i = 0; i < journals.Count; i++)
+                {
+                    if (journals[i].AllPosition == null || journals[i].AllPosition.Count == 0)
+                    {
+                        continue;
+                    }
+                    pos.AddRange(journals[i].AllPosition);
+                }
+                return pos.Count;
+            }
+        }
+
         // working with strategy parameters / работа с параметрами стратегии
 
         /// <summary>


### PR DESCRIPTION
Добавил в таблицу с роботами в лайт-интерфейсе информацию и обо всех позициях:
![Кол-во поз](https://user-images.githubusercontent.com/109503835/218029312-44b483ec-eecc-489b-8490-23f1f3e799ff.png)
Может быть полезным видеть не только сколько открытых позиций, но и сколько всего позиций было.  Так же сделано в Скринерах сейчас, на практике бывает нужно.