### PR TITLE
Fix window visibility after restart from taskbar close

### DIFF
--- a/project/OsEngine/App.xaml.cs
+++ b/project/OsEngine/App.xaml.cs
@@ -63,8 +63,7 @@ namespace OsEngine
 
         void MinButtonClick(object sender, RoutedEventArgs e)
         {
-            
-            sender.ForWindowFromTemplate(w => SystemCommands.MinimizeWindow(w));
+            sender.ForWindowFromTemplate(w => w.WindowState = WindowState.Minimized);
         }
 
         void MaxButtonClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Если окно было закрыто в свернутом виде, то при перезапуске оно переставало отображаться. Приходилось через таскбар его разворачивать