### PR TITLE
Адаптация открытия вспом. окон на ПК с несколькими мониторами

### DIFF
--- a/project/OsEngine/Layout/DesktopCoordinates.cs
+++ b/project/OsEngine/Layout/DesktopCoordinates.cs
@@ -45,18 +45,6 @@ namespace OsEngine.Layout
             return point.X;
         }
 
-        public static double CurrentScreenWidth()
-        {
-            int width = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Size.Width;
-            return width;
-        }
-
-        public static double CurrentScreenHeight()
-        {
-            int height = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Size.Height;
-            return height;
-        }
-
     }
     public struct POINT
     {

--- a/project/OsEngine/Layout/StartupLocation.cs
+++ b/project/OsEngine/Layout/StartupLocation.cs
@@ -69,34 +69,31 @@ namespace OsEngine.Layout
             double leftPos = xPosByWin32 - ui.Width/2;
             double topPos = yPosByWin32 - ui.Height / 2;
 
+            System.Drawing.Rectangle actualArea = new System.Drawing.Rectangle();     
+            actualArea = System.Windows.Forms.Screen.GetBounds(System.Windows.Forms.Control.MousePosition);   
+
             // проверка разворачивания окна за экраном слева и сверху
 
-            if (leftPos < 0)
+            if (leftPos < actualArea.X)    
             {
-                leftPos = 0;
+                leftPos = actualArea.X;
             }
 
-            if(topPos < 0)
+            if (topPos < actualArea.Y)           
             {
-                topPos = 0;
+                topPos = actualArea.Y;
             }
 
             // проверка разворачивания окна за экраном вправо и вниз
 
-            double xPosMouseOld = DesktopCoordinates.XmousePosOldVersion();
-            double yPosMouseOld = DesktopCoordinates.YmousePosOldVersion();
-
-            double screenWidth = DesktopCoordinates.CurrentScreenWidth();
-            double screenHeight = DesktopCoordinates.CurrentScreenHeight();
-
-            if(xPosMouseOld + ui.Width / 2 > screenWidth)
+            if(leftPos + ui.Width > actualArea.X + actualArea.Width)   
             {
-                leftPos = xPosByWin32 - ui.Width;
+                leftPos = actualArea.X + actualArea.Width - ui.Width;
             }
 
-            if (yPosMouseOld + ui.Height / 2 > screenHeight)
+            if (topPos + ui.Height > actualArea.Y + actualArea.Height)         
             {
-                topPos = yPosByWin32 - ui.Height;
+                topPos = actualArea.Y + actualArea.Height - ui.Height;
             }
 
             // устанавливаем окончательные значения


### PR DESCRIPTION
Открытие вспомогательных окон в системах с несколькими мониторами работало неверно. 
А именно - вспомогательные окна открывались на основном мониторе, если основное окно OsEngine было на другом мониторе сверху или слева от основного. Или если монитор справа или снизу от основного, то слева и сверху от курсора. Т.е. не работало адекватно, если OsEngine не на основном мониторе.

Подправил это - теперь вспомогательные окна всегда открываются на активном мониторе, т.е. на мониторе, где и основное окно. Так же сохранен возврат окна на экран при выпадении его за области этого экрана.