### PR TITLE
Установка для Чарта ТаймФрема, при его отложенном создании. (в скрине…

### DIFF
--- a/project/OsEngine/Charts/CandleChart/ChartCandleMaster.cs
+++ b/project/OsEngine/Charts/CandleChart/ChartCandleMaster.cs
@@ -65,6 +65,7 @@ namespace OsEngine.Charts.CandleChart
             ChartCandle.LogMessageEvent += NewLogMessage;
             ChartCandle.ClickToIndexEvent += _chartCandle_ClickToIndexEvent;
             ChartCandle.SizeAxisXChangeEvent += ChartCandle_SizeAxisXChangeEvent;
+            SetNewTimeFrameToChart(_timeFrameBuilder);  //AVP добавил, чтоб ChartCandle знал, с каким он таймфреймом. (Это важно для скринера, с отложенным созданием Чарта)  
 
             if (_indicators != null)
             {
@@ -75,6 +76,27 @@ namespace OsEngine.Charts.CandleChart
             }
 
            
+        }
+
+        /// <summary>
+        /// Установить TimeFrame на чарт    
+        /// Set TimeFrame to Chart
+        /// </summary>
+        /// <param name="timeFrameBuilder"></param>
+        private void SetNewTimeFrameToChart(TimeFrameBuilder timeFrameBuilder)      //AVP
+        {
+            if (timeFrameBuilder == null || ChartCandle == null)
+            {
+                return;
+            }
+            if (timeFrameBuilder.CandleCreateMethodType != CandleCreateMethodType.Simple)
+            {
+                ChartCandle.SetNewTimeFrame(TimeSpan.FromSeconds(1), timeFrameBuilder.TimeFrame);
+            }
+            else
+            {
+                ChartCandle.SetNewTimeFrame(timeFrameBuilder.TimeFrameTimeSpan, timeFrameBuilder.TimeFrame);
+            }
         }
 
         /// <summary>
@@ -1624,14 +1646,15 @@ namespace OsEngine.Charts.CandleChart
             if (ChartCandle != null)
             {
                 ChartCandle.ClearDataPointsAndSizeValue();
-                if (timeFrameBuilder.CandleCreateMethodType != CandleCreateMethodType.Simple)
+                SetNewTimeFrameToChart(timeFrameBuilder);   //AVP  рефакторинг, чтоб нижний код два раза не повторялся.
+                /*if (timeFrameBuilder.CandleCreateMethodType != CandleCreateMethodType.Simple) // AVP этот код перенес в SetNewTimeFrameToChart
                 {
                     ChartCandle.SetNewTimeFrame(TimeSpan.FromSeconds(1), timeFrameBuilder.TimeFrame);
                 }
                 else
                 {
                     ChartCandle.SetNewTimeFrame(timeFrameBuilder.TimeFrameTimeSpan, timeFrameBuilder.TimeFrame);
-                }
+                }*/
             }
 
             string lastSecurity = _securityOnThisChart;


### PR DESCRIPTION
Установка для Чарта ТаймФрема, при его отложенном создании. (в скринерах)
Исправлен баг: В скринере, при нажатии на кнопку Чарт, он  создавался, но инфа о таймфрейме в Чарт не попадала. 
В итоге на чарте не верно работал поиск, и реальные сделки отрисовывались на чарте в другую свечку.
Внес изменения, при создании чарта, принудительно ему ставлю таймфрем.