### PR TITLE
Корректная обработка шортовых позиций по акциям в коннекторе Тинькофф Инвестиций

### DIFF
--- a/project/OsEngine/Market/Servers/Tinkoff/TinkoffJsonSchema/Portfolios.cs
+++ b/project/OsEngine/Market/Servers/Tinkoff/TinkoffJsonSchema/Portfolios.cs
@@ -19,6 +19,18 @@ namespace OsEngine.Market.Servers.Tinkoff.TinkoffJsonSchema
 
         public decimal GetValue()
         {
+            decimal unitsDecimal = units.ToDecimal();
+
+            if (unitsDecimal < 0 && _value == Decimal.MinValue)
+            {
+                return unitsDecimal;
+            }
+
+            if (unitsDecimal < 0 && _value > 0 )
+            {
+                _value = -_value;
+            }
+
             if (_value != Decimal.MinValue)
             {
                 return _value;

--- a/project/OsEngine/Market/Servers/Tinkoff/TinkoffJsonSchema/Securities.cs
+++ b/project/OsEngine/Market/Servers/Tinkoff/TinkoffJsonSchema/Securities.cs
@@ -61,6 +61,18 @@ namespace OsEngine.Market.Servers.Tinkoff.TinkoffJsonSchema
 
         public decimal GetValue()
         {
+            decimal unitsDecimal = units.ToDecimal();
+
+            if (unitsDecimal < 0 && _value == Decimal.MinValue)
+            {
+                return unitsDecimal;
+            }
+
+            if (unitsDecimal < 0 && _value > 0 )
+            {
+                _value = -_value;
+            }
+
             if(_value != Decimal.MinValue)
             {
                 return _value;


### PR DESCRIPTION
От сервера приходит корректное количество акций с минусом.
Раньше оно отображалось с плюсом и в результате активы отображались неверно.
Исправил и проверил на реальном счете.