### PR TITLE
Подсветка выбранной строки в таблице выбора инструментов

### DIFF
--- a/project/OsEngine/Market/Connectors/ConnectorCandlesUi.xaml.cs
+++ b/project/OsEngine/Market/Connectors/ConnectorCandlesUi.xaml.cs
@@ -1047,9 +1047,28 @@ namespace OsEngine.Market.Connectors
 
         private void _gridSecurities_CellClick(object sender, DataGridViewCellEventArgs e)
         {
+            _gridSecurities.ClearSelection(); 
+			
             int columnInd = e.ColumnIndex;
-
             int rowInd = e.RowIndex;
+
+            for (int i = 0; i < _gridSecurities.RowCount; i++)
+            {
+                if (i == rowInd)
+                {
+                    for (int y = 0; y < _gridSecurities.ColumnCount; y++)
+                    {
+                        _gridSecurities.Rows[rowInd].Cells[y].Style.ForeColor = System.Drawing.ColorTranslator.FromHtml("#ffffff");
+                    }
+                }
+                else
+                {
+                    for (int y = 0; y < _gridSecurities.ColumnCount; y++)
+                    {
+                        _gridSecurities.Rows[i].Cells[y].Style.ForeColor = System.Drawing.ColorTranslator.FromHtml("#FFA1A1A1");
+                    }
+                }
+            }
 
             if(columnInd != 4)
             {

--- a/project/OsEngine/Market/Connectors/MassSourcesCreateUi.xaml.cs
+++ b/project/OsEngine/Market/Connectors/MassSourcesCreateUi.xaml.cs
@@ -247,7 +247,8 @@ namespace OsEngine.Market.Connectors
             ButtonRightInSearchResults.Click -= ButtonRightInSearchResults_Click;
             ButtonLeftInSearchResults.Click -= ButtonLeftInSearchResults_Click;
             _sorcesCreator = null;
-
+			
+            _gridSecurities.CellClick -= _gridSecurities_CellClick;
 
             Closed -= MassSourcesCreateUi_Closed;
 
@@ -873,9 +874,33 @@ namespace OsEngine.Market.Connectors
             colum6.Width = 50;
             newGrid.Columns.Add(colum6);
 
-
             _gridSecurities = newGrid;
             SecuritiesHost.Child = _gridSecurities;
+			
+            _gridSecurities.CellClick += _gridSecurities_CellClick;		
+        }
+
+        private void _gridSecurities_CellClick(object sender, DataGridViewCellEventArgs e)
+        {
+            _gridSecurities.ClearSelection();
+
+            for (int i = 0; i < _gridSecurities.RowCount; i++)
+            {
+                if (i == e.RowIndex)
+                {
+                    for (int y = 0; y < _gridSecurities.ColumnCount; y++)
+                    {
+                        _gridSecurities.Rows[e.RowIndex].Cells[y].Style.ForeColor = System.Drawing.ColorTranslator.FromHtml("#ffffff");
+                    }
+                }
+                else
+                {
+                    for (int y = 0; y < _gridSecurities.ColumnCount; y++)
+                    {
+                        _gridSecurities.Rows[i].Cells[y].Style.ForeColor = System.Drawing.ColorTranslator.FromHtml("#FFA1A1A1");
+                    }
+                }
+            }
         }
 
         private void UpdateGrid(List<Security> securities)

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabScreenerUi.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabScreenerUi.xaml.cs
@@ -246,6 +246,7 @@ namespace OsEngine.OsTrader.Panels.Tab
             ButtonRightInSearchResults.Click -= ButtonRightInSearchResults_Click;
             ButtonLeftInSearchResults.Click -= ButtonLeftInSearchResults_Click;
 
+            _gridSecurities.CellClick -= _gridSecurities_CellClick;
 
             Closed -= BotTabScreenerUi_Closed;
 
@@ -877,9 +878,33 @@ namespace OsEngine.OsTrader.Panels.Tab
             colum6.Width = 50;
             newGrid.Columns.Add(colum6);
 
-
             _gridSecurities = newGrid;
             SecuritiesHost.Child = _gridSecurities;
+
+            _gridSecurities.CellClick += _gridSecurities_CellClick;			
+        }
+
+        private void _gridSecurities_CellClick(object sender, DataGridViewCellEventArgs e)
+        {
+            _gridSecurities.ClearSelection();
+
+            for (int i = 0; i < _gridSecurities.RowCount; i++)
+            {
+                if (i == e.RowIndex)
+                {
+                    for (int y = 0; y < _gridSecurities.ColumnCount; y++)
+                    {
+                        _gridSecurities.Rows[e.RowIndex].Cells[y].Style.ForeColor = System.Drawing.ColorTranslator.FromHtml("#ffffff");
+                    }
+                }
+                else
+                {
+                    for (int y = 0; y < _gridSecurities.ColumnCount; y++)
+                    {
+                        _gridSecurities.Rows[i].Cells[y].Style.ForeColor = System.Drawing.ColorTranslator.FromHtml("#FFA1A1A1");
+                    }
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Подружелюбнее сделал поведение таблицы выбора инструментов. Стандартное выделение строки с тикером при скроллинге перескакивало тоже, что сбивало с толку, путало.
Теперь выделенная строка при скроллинге таблицы не скроллится, а сохраняет выделение - стало удобнее листать список тикеров, ориентируясь на выделенную строку, до куда листать, где закончил и тд.

Было так:

https://github.com/AlexWan/OsEngine/assets/109503835/8362144a-b188-4858-892e-8399ec342c9b


Стало так:

https://github.com/AlexWan/OsEngine/assets/109503835/b5032438-911c-4faa-8e6f-51ff0055de83



