### PR TITLE
Update ServerTickStorage.cs

### DIFF
--- a/project/OsEngine/Market/Servers/ServerTickStorage.cs
+++ b/project/OsEngine/Market/Servers/ServerTickStorage.cs
@@ -167,7 +167,7 @@ namespace OsEngine.Market.Servers
                             _tradeSaveInfo.Add(tradeInfo);
                         }
 
-                        if (tradeInfo.LastSaveIndex == allTrades[i1].Count)
+                        if (tradeInfo.LastSaveIndex >= allTrades[i1].Count)
                         {
                             continue;
                         }


### PR DESCRIPTION
Исправление не фатальной ошибки.
Проявляется при подключении к Binance (может ещё где). Понятно, что патч не устраняет проблему (возможно что-то сделано не потокобезопасно).

Error;System.ArgumentOutOfRangeException: Индекс за пределами диапазона. Индекс должен быть положительным числом, а его размер не должен превышать размер коллекции. Имя параметра: index
   в System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
   в System.Collections.Generic.List`1.get_Item(Int32 index)
   в OsEngine.Market.Servers.ServerTickStorage.TickSaverSpaceInOneFile();