### PR TITLE
При таймфреймах более 1 часа загружаем историю по 7 дней за один запрос

### DIFF
--- a/project/OsEngine/Market/Servers/Tinkoff/TinkoffClient.cs
+++ b/project/OsEngine/Market/Servers/Tinkoff/TinkoffClient.cs
@@ -277,6 +277,13 @@ namespace OsEngine.Market.Servers.Tinkoff
         {
             List<Candle> candles = new List<Candle>();
 
+            int days = 1; // период, за который запрашивать свечи 
+
+            if (tf >= TimeFrame.Hour1)
+            {
+                days = 7; // Tinkoff api позволяет запрашивать большие интервалы данных для таймфреймов более 1 часа
+            }
+
             while (from.Hour > 1)
             {
                 from = from.AddHours(-1);
@@ -294,15 +301,15 @@ namespace OsEngine.Market.Servers.Tinkoff
 
             while (from <= to)
             {
-                candles.AddRange(GetCandleHistoryFromDay(from, nameId, tf));
+                candles.AddRange(GetCandleHistoryFromDays(from, nameId, tf, days));
 
-                from = from.AddDays(1);
+                from = from.AddDays(days);
             }
 
             return candles;
         }
 
-        private List<Candle> GetCandleHistoryFromDay(DateTime time, string nameSec, TimeFrame tf)
+        private List<Candle> GetCandleHistoryFromDays(DateTime time, string nameSec, TimeFrame tf, int days = 1)
         {
             /* {
                  "figi": "string",
@@ -319,7 +326,7 @@ namespace OsEngine.Market.Servers.Tinkoff
             string dateFrom = ToIso8601(time);
             param.Add("from", dateFrom);
 
-            string dateTo = ToIso8601(time.AddDays(1));
+            string dateTo = ToIso8601(time.AddDays(days));
             param.Add("to", dateTo);
 
             string tfStr = CreateTimeFrameString(tf);


### PR DESCRIPTION
Если много инструментов (десятки), то подгрузка исторических данных становится очень долгой так как данные загружаются по одному дню за запрос. 

В случае таймфреймов от часовика и старше API позволяет запрашивать сразу 7 и более дней.
Загрузка исторических данных в таком случае происходит в разы быстрее и не создает проблем при десятках инструментов.