### PR TITLE
Update QuikLuaServer.cs - торговля ценными бумагами через Демо-QUIK

### DIFF
--- a/project/OsEngine/Market/Servers/QuikLua/QuikLuaServer.cs
+++ b/project/OsEngine/Market/Servers/QuikLua/QuikLuaServer.cs
@@ -248,7 +248,7 @@ namespace OsEngine.Market.Servers.QuikLua
         
             {
                 
-                if (classesSec.EndsWith ("TQBR") || classesSec.EndsWith("TQOB"))
+                if (classesSec.EndsWith ("TQBR") || classesSec.EndsWith("TQOB") || classesSec.EndsWith("QJSIM"))
                 {
                     if (_useStock.Value)
                     {


### PR DESCRIPTION
OsEngine не позволяет через демо-версию QUIK торговать ценными бумагами (тип Stock), так как в "Настройках данных" невозможно выбрать класс бумаг QJSIM, который используется в демо-QUIK для ценных бумаг. Добавляем класс бумаг QJSIM.