### PR TITLE
Update BotTabSimple.cs - PositionsOnBoard возвращает пустую коллекцию

### DIFF
--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabSimple.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabSimple.cs
@@ -930,7 +930,7 @@ namespace OsEngine.OsTrader.Panels.Tab
                             continue;
                         }
 
-                        if (positionsOnBoard[i].SecurityNameCode.Contains(Securiti.Name))
+                        if (positionsOnBoard[i].SecurityNameCode.Contains(Securiti.Name.Split(new char[] { '+' })[0]))
                         {
                             posesWithMySecurity.Add(positionsOnBoard[i]);
                         }


### PR DESCRIPTION
Свойство BotTabSimple.PositionsOnBoard всегда возвращает пустую коллекцию независимо от наличии биржевой позиции. В этом свойстве забирается из Portfolio коллекция всех биржевых позиций по всем инструментам и ищется совпадение с текущим инструментом вкладки BotTabSimple, код которого содержится в Securiti.Name. Проблема в том, что поле Securiti.Name содержит название инструмента в формате "код инструмента + код класса" (например, SBER+TQBR). А в коллекции, полученной из Portfolio, поле SecurityNameCode содержит только код инструмента (например, SBER). Предлагаемое решение: Securiti.Name разделить символом '+' на две подстроки ("код инструмента" и "код класса") и при сравнении использовать только первую подстроку ("код инструмента").