### PR TITLE
Добавил учет лотности позиций для Алора

### DIFF
--- a/project/OsEngine/Entity/Position.cs
+++ b/project/OsEngine/Entity/Position.cs
@@ -1081,6 +1081,7 @@ namespace OsEngine.Entity
                     OpenOrders[0].ServerType == ServerType.QuikDde ||
                     OpenOrders[0].ServerType == ServerType.QuikLua ||
                     OpenOrders[0].ServerType == ServerType.Tinkoff ||
+                    OpenOrders[0].ServerType == ServerType.Alor ||
                     OpenOrders[0].ServerType == ServerType.Transaq)
                 {
                     return true;


### PR DESCRIPTION
При работе через Алор в интерфейсе отображалась неверно прибыль для акций, у которых лот не равен 1. Добавил учет лотности для Алора.