### PR TITLE
Убрал вылезающее сообщение об ошибке про разъединение с сервером Алора

### DIFF
--- a/project/OsEngine/Market/Servers/Alor/AlorServer.cs
+++ b/project/OsEngine/Market/Servers/Alor/AlorServer.cs
@@ -207,7 +207,7 @@ namespace OsEngine.Market.Servers.Alor
 
             DeleteWebSocketConnection();
 
-            SendLogMessage("Connection Closed by Alor. WebSocket Data Closed Event", LogMessageType.Error);
+            SendLogMessage("Connection Closed by Alor. WebSocket Data Closed Event", LogMessageType.System);
 
             if (ServerStatus != ServerConnectStatus.Disconnect)
             {


### PR DESCRIPTION
При запуске сервера Алор вылезало сообщение об ошибке в критический лог.
Изменил приоритет сообщения, чтобы оно никого не пугало.