### PR TITLE
Fix BotTabSimple.PositionsOnBoard для QuikLua (Спот)

### DIFF
--- a/project/OsEngine/Market/Servers/QuikLua/QuikLuaServer.cs
+++ b/project/OsEngine/Market/Servers/QuikLua/QuikLuaServer.cs
@@ -644,7 +644,9 @@ namespace OsEngine.Market.Servers.QuikLua
                     Portfolio needPortf;
                     foreach (var pos in spotPos)
                     {
-                        if (pos.LimitKind == LimitKind.T0)
+                        Security sec = _securities.Find(sec => sec.Name.Split('+')[0] == pos.SecCode);
+                        
+                        if (pos.LimitKind == LimitKind.T0 && sec != null)
                         {
                             needPortf = _portfolios.Find(p => p.Number == pos.TrdAccId);
 
@@ -656,7 +658,7 @@ namespace OsEngine.Market.Servers.QuikLua
                                 position.ValueBegin = pos.OpenBalance;
                                 position.ValueCurrent = pos.CurrentBalance;
                                 position.ValueBlocked = pos.LockedSell;
-                                position.SecurityNameCode = pos.SecCode;
+                                position.SecurityNameCode = sec.Name;
 
                                 needPortf.SetNewPosition(position);
                             }


### PR DESCRIPTION
Bug: для соединения QuikLua свойство BotTabSimple.PositionsOnBoard всегда возвращает пустую коллекцию независимо от наличии биржевой позиции по споту. Проблема в том, что для соединения QuikLua поле Securiti.Name содержит название инструмента в формате "код инструмента+код класса" (например, "SBER+TQBR"). А в коллекции, возвращаемой методом GetPositionOnBoard(), поле SecurityNameCode содержит только код инструмента (например, "SBER"). Поэтому помещаем в поле SecurityNameCode названия инструментов в формате "код инструмента+код класса". Для этого код инструмента из коллекции, полученной из QUIK (таблица "Лимиты по бумагам") ищем в коллекции  _securities, где названия инструментов уже представлены в формате "код инструмента + код класса", и при совпадении добавляем в поле SecurityNameCode.