### PR TITLE
Fix BotTabSimple.PositionsOnBoard для QuikLua (Фьючерсы)

### DIFF
--- a/project/OsEngine/Market/Servers/QuikLua/QuikLuaServer.cs
+++ b/project/OsEngine/Market/Servers/QuikLua/QuikLuaServer.cs
@@ -1332,20 +1332,25 @@ namespace OsEngine.Market.Servers.QuikLua
                         {
                             return;
                         }
+                        
+                        Security sec = _securities.Find(sec => sec.Name.Split('+')[0] == futPos.secCode);
 
-                        PositionOnBoard newPos = new PositionOnBoard();
-
-                        newPos.PortfolioName = futPos.trdAccId;
-                        newPos.SecurityNameCode = futPos.secCode;
-                        newPos.ValueBegin = Convert.ToDecimal(futPos.startNet);
-                        newPos.ValueCurrent = Convert.ToDecimal(futPos.totalNet);
-                        newPos.ValueBlocked = 0;
-
-                        needPortfolio.SetNewPosition(newPos);
-
-                        if (PortfolioEvent != null)
+                        if (sec != null)
                         {
-                            PortfolioEvent(_portfolios);
+                            PositionOnBoard newPos = new PositionOnBoard();
+
+                            newPos.PortfolioName = futPos.trdAccId;
+                            newPos.SecurityNameCode = sec.Name;
+                            newPos.ValueBegin = Convert.ToDecimal(futPos.startNet);
+                            newPos.ValueCurrent = Convert.ToDecimal(futPos.totalNet);
+                            newPos.ValueBlocked = 0;
+
+                            needPortfolio.SetNewPosition(newPos);
+
+                            if (PortfolioEvent != null)
+                            {
+                                PortfolioEvent(_portfolios);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Bug: для соединения QuikLua свойство BotTabSimple.PositionsOnBoard всегда возвращает пустую коллекцию независимо от наличии биржевой позиции по фьючерсам. Проблема в том, что для соединения QuikLua поле Securiti.Name содержит название инструмента в формате "код инструмента+код класса" (например, "SiH4+SPBFUT"). А в коллекции, возвращаемой методом GetPositionOnBoard(), поле SecurityNameCode содержит только код инструмента (например, "SiH4"). Поэтому помещаем в поле SecurityNameCode названия инструментов в формате "код инструмента+код класса". Для этого в обработчике получения позиции по клиентским счетам (фьючерсы) полученный код инструмента ищем в коллекции _securities, где названия инструментов уже представлены в формате "код инструмента+код класса", и при совпадении добавляем в поле SecurityNameCode.