### PR TITLE
Visual edit in settings window Os.Data

### DIFF
--- a/project/OsEngine/OsData/OsDataSetUi.xaml
+++ b/project/OsEngine/OsData/OsDataSetUi.xaml
@@ -42,7 +42,7 @@
         <Button Name="ButtonAccept" Content="Accept" HorizontalAlignment="Right" Margin="0,0,10,29" VerticalAlignment="Bottom" Width="191" Click="ButtonAccept_Click"/>
         <CheckBox x:Name="CheckBoxTf4HourIsOn" Content="4 hour" HorizontalAlignment="Left" Margin="270,163,0,0" VerticalAlignment="Top" />
         <Rectangle x:Name="StopUsePanelOne" HorizontalAlignment="Left" Height="144" Margin="18,91,0,0" Stroke="Black" VerticalAlignment="Top" Width="338" Opacity="0.5" StrokeThickness="0"/>
-        <Rectangle x:Name="StopUsePanelTwo" HorizontalAlignment="Left" Height="26" Margin="297,298,0,0" Stroke="Black" VerticalAlignment="Top" Width="125" Opacity="0.5" StrokeThickness="0"/>
+        <Rectangle x:Name="StopUsePanelTwo" HorizontalAlignment="Left" Height="26" Margin="297,298,0,0" Stroke="Black" VerticalAlignment="Top" Width="130" Opacity="0.5" StrokeThickness="0"/>
        
     </Grid>
 </Window>

--- a/project/OsEngine/OsData/OsDataSetUi.xaml
+++ b/project/OsEngine/OsData/OsDataSetUi.xaml
@@ -42,7 +42,7 @@
         <Button Name="ButtonAccept" Content="Accept" HorizontalAlignment="Right" Margin="0,0,10,29" VerticalAlignment="Bottom" Width="191" Click="ButtonAccept_Click"/>
         <CheckBox x:Name="CheckBoxTf4HourIsOn" Content="4 hour" HorizontalAlignment="Left" Margin="270,163,0,0" VerticalAlignment="Top" />
         <Rectangle x:Name="StopUsePanelOne" HorizontalAlignment="Left" Height="144" Margin="18,91,0,0" Stroke="Black" VerticalAlignment="Top" Width="338" Opacity="0.5" StrokeThickness="0"/>
-        <Rectangle x:Name="StopUsePanelTwo" HorizontalAlignment="Left" Height="26" Margin="297,298,0,0" Stroke="Black" VerticalAlignment="Top" Width="106" Opacity="0.5" StrokeThickness="0"/>
+        <Rectangle x:Name="StopUsePanelTwo" HorizontalAlignment="Left" Height="26" Margin="297,298,0,0" Stroke="Black" VerticalAlignment="Top" Width="125" Opacity="0.5" StrokeThickness="0"/>
        
     </Grid>
 </Window>


### PR DESCRIPTION
Когда русский язык, , то затенение не полностью захватывало:
![16f1](https://github.com/AlexWan/OsEngine/assets/109503835/b00934ba-f3ba-436f-b604-7ad51f48055b)
