### PR TITLE
MoexFixFastSpot: Убрал подключение к MFIX Trade Capture как излишнее 

### DIFF
--- a/project/OsEngine/Market/Servers/MoexFixFastSpot/FIX/OrderMassCancelRequestMessage.cs
+++ b/project/OsEngine/Market/Servers/MoexFixFastSpot/FIX/OrderMassCancelRequestMessage.cs
@@ -22,7 +22,7 @@ namespace OsEngine.Market.Servers.MoexFixFastSpot.FIX
             string TradingSessionIDString = MassCancelRequestType == "1" ? $"336={TradingSessionID}\u0001" : "";
             string Instrument = MassCancelRequestType == "1" ? $"55={Symbol}\u0001" : "";
 
-            return $"11={ClOrdID}\u0001530={MassCancelRequestType}\u0001{TradingSessionIDString}{Instrument}160={TransactTime}\u00011={Account}\u0001453={NoPartyID}\u0001448={PartyID}\u0001447={PartyIDSource}\u0001452={PartyRole}\u0001";
+            return $"11={ClOrdID}\u0001530={MassCancelRequestType}\u0001{TradingSessionIDString}{Instrument}60={TransactTime}\u00011={Account}\u0001453={NoPartyID}\u0001448={PartyID}\u0001447={PartyIDSource}\u0001452={PartyRole}\u0001";
         }
     }
 }

--- a/project/OsEngine/Market/Servers/MoexFixFastSpot/MoexFixFastSpotServer.cs
+++ b/project/OsEngine/Market/Servers/MoexFixFastSpot/MoexFixFastSpotServer.cs
@@ -3705,7 +3705,7 @@ namespace OsEngine.Market.Servers.MoexFixFastSpot
 
                 OrderMassCancelRequestMessage msg = new OrderMassCancelRequestMessage();
                 msg.ClOrdID = DateTime.UtcNow.Ticks.ToString(); // идентификатор заявки на снятие
-                msg.MassCancelRequestType = "7";
+                msg.MassCancelRequestType = "1";
                 msg.TradingSessionID = security.NameClass;
                 msg.Symbol = security.NameId;
                 msg.TransactTime = DateTime.UtcNow.ToString("yyyyMMdd-HH:mm:ss.fff");


### PR DESCRIPTION


Оптимизировал использование ресурсов.
Убрал подключение к дополнительному FIX-серверу, через который получались данные MyTrade.
Теперь все данные получаются через единственное подключение к MFIX Trade. Соответственно цена подключение к FIX снизилась вдвое.

-     убрал лишние параметры;
-     убрал поток, управляющий подключением.
 
