### PR TITLE
быстрый парсинг датывремени из строки

### DIFF
--- a/project/OsEngine/Candles/Candle.cs
+++ b/project/OsEngine/Candles/Candle.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using OsEngine.Helpers;
 
 namespace OsEngine.Entity
 {
@@ -272,15 +273,7 @@ namespace OsEngine.Entity
             //<DATE>,<TIME>,<OPEN>,<HIGH>,<LOW>,<CLOSE>,<VOLUME>
             string[] sIn = In.Split(',');
 
-            int year = Convert.ToInt32(sIn[0].Substring(0, 4));
-            int month = Convert.ToInt32(sIn[0].Substring(4, 2));
-            int day = Convert.ToInt32(sIn[0].Substring(6, 2));
-
-            int hour = Convert.ToInt32(sIn[1].Substring(0, 2));
-            int minute = Convert.ToInt32(sIn[1].Substring(2, 2));
-            int second = Convert.ToInt32(sIn[1].Substring(4, 2));
-
-            TimeStart = new DateTime(year, month, day, hour, minute, second);
+            TimeStart = DateTimeParseHelper.ParseFromTwoStrings(sIn[0], sIn[1]);
 
             Open = sIn[2].ToDecimal();
             High = sIn[3].ToDecimal();

--- a/project/OsEngine/Entity/MarketDepth.cs
+++ b/project/OsEngine/Entity/MarketDepth.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using OsEngine.Helpers;
 
 namespace OsEngine.Entity
 {
@@ -78,19 +79,9 @@ namespace OsEngine.Entity
         {
             string[] save = str.Split('_');
 
-            int year =
-            Convert.ToInt32(save[0][0].ToString() + save[0][1].ToString() + save[0][2].ToString() +
-                      save[0][3].ToString());
-            int month = Convert.ToInt32(save[0][4].ToString() + save[0][5].ToString());
-            int day = Convert.ToInt32(save[0][6].ToString() + save[0][7].ToString());
-            int hour = Convert.ToInt32(save[1][0].ToString() + save[1][1].ToString());
-            int minute = Convert.ToInt32(save[1][2].ToString() + save[1][3].ToString());
-            int second = Convert.ToInt32(save[1][4].ToString() + save[1][5].ToString());
-
-            Time = new DateTime(year, month, day, hour, minute, second);
+            Time = DateTimeParseHelper.ParseFromTwoStrings(save[0], save[1]);
 
             Time = Time.AddMilliseconds(Convert.ToInt32(save[2]));
-
             
             string[] bids = save[3].Split('*');
 

--- a/project/OsEngine/Entity/Trade.cs
+++ b/project/OsEngine/Entity/Trade.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Globalization;
+using OsEngine.Helpers;
 
 namespace OsEngine.Entity
 {
@@ -154,15 +155,7 @@ namespace OsEngine.Entity
                 return;
             }
 
-            int year = Convert.ToInt32(sIn[0].Substring(0, 4));
-            int month = Convert.ToInt32(sIn[0].Substring(4, 2)); 
-            int day = Convert.ToInt32(sIn[0].Substring(6, 2));
-
-            int hour = Convert.ToInt32(sIn[1].Substring(0, 2));
-            int minute = Convert.ToInt32(sIn[1].Substring(2, 2));
-            int second = Convert.ToInt32(sIn[1].Substring(4, 2));
-
-            Time = new DateTime(year, month, day, hour, minute, second);
+            Time = DateTimeParseHelper.ParseFromTwoStrings(sIn[0], sIn[1]);
             
             Price = sIn[2].ToDecimal();
 

--- a/project/OsEngine/Helpers/DateTimeParseHelper.cs
+++ b/project/OsEngine/Helpers/DateTimeParseHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace OsEngine.Helpers
+{
+    /// <summary>
+    /// Вспомогательные функции для парсинга даты-времени.
+    /// </summary>
+    public static class DateTimeParseHelper
+    {
+        /// <summary>
+        /// Парсит дату-время из двух строк, строки даты и строки времени.
+        /// </summary>
+        /// <param name="dateString">Строка даты в формате "YYYYMMDD".</param>
+        /// <param name="timeString">Строка времени в формате "HHmmSS".</param>
+        public static DateTime ParseFromTwoStrings(string dateString, string timeString)
+        {
+            ParseDateOrTimeString(dateString, out int year, out int month, out int day);
+            ParseDateOrTimeString(timeString, out int hour, out int minute, out int second);
+            return new DateTime(year, month, day, hour, minute, second);
+        }
+
+        /// <summary>
+        /// Парсит строку даты или времени в выходные переменные год-месяц-день (если строка даты) либо час-минута-секунда (если строка времени).
+        /// </summary>
+        /// <remarks>
+        /// Хоть строки и представляют собой разные сущности, логика парсинга одинакова.
+        /// </remarks>
+        public static void ParseDateOrTimeString(string dateOrTimeString, out int yearHour, out int monthMinute, out int daySecond)
+        {
+            // по-хорошему сделать бы проверок на длину хотя бы, но, с другой стороны, это будет медленнее, да и все равно, как падать, если все равно падать
+            int dateOrTimeInt = Convert.ToInt32(dateOrTimeString);
+            yearHour = dateOrTimeInt / 10000;
+            monthMinute = dateOrTimeInt / 100 % 100;
+            daySecond = dateOrTimeInt % 100;
+        }
+    }
+}

--- a/project/OsEngine/Market/Servers/AstsBridge/AstsBridgeWrapper.cs
+++ b/project/OsEngine/Market/Servers/AstsBridge/AstsBridgeWrapper.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using OsEngine.Entity;
+using OsEngine.Helpers;
 using OsEngine.Logging;
 
 namespace OsEngine.Market.Servers.AstsBridge
@@ -2116,9 +2117,7 @@ namespace OsEngine.Market.Servers.AstsBridge
 
             if (fieldT != null)
             {
-                hour = Convert.ToInt32(fieldT.Value[0].ToString() + fieldT.Value[1].ToString());
-                min = Convert.ToInt32(fieldT.Value[2].ToString() + fieldT.Value[3].ToString());
-                sec = Convert.ToInt32(fieldT.Value[4].ToString() + fieldT.Value[5].ToString());
+                DateTimeParseHelper.ParseDateOrTimeString(fieldT.Value, out hour, out min, out sec);
             }
 
             int day = 0;
@@ -2127,9 +2126,7 @@ namespace OsEngine.Market.Servers.AstsBridge
 
             if (fieldD != null)
             {
-                day = Convert.ToInt32(fieldD.Value[6].ToString() + fieldD.Value[7].ToString());
-                month = Convert.ToInt32(fieldD.Value[4].ToString() + fieldD.Value[5].ToString());
-                year = Convert.ToInt32(fieldD.Value[0].ToString() + fieldD.Value[1].ToString() + fieldD.Value[2].ToString() + fieldD.Value[3].ToString());
+                DateTimeParseHelper.ParseDateOrTimeString(fieldD.Value, out year, out month, out day);
             }
 
             DateTime result = new DateTime(year, month, day, hour, min, sec);

--- a/project/OsEngine/Market/Servers/MFD/MfdServer.cs
+++ b/project/OsEngine/Market/Servers/MFD/MfdServer.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Windows;
-using Newtonsoft.Json.Linq;
 using OsEngine.Entity;
+using OsEngine.Helpers;
 using OsEngine.Logging;
 using OsEngine.Market.Servers.Entity;
 
@@ -395,15 +394,7 @@ namespace OsEngine.Market.Servers.MFD
 
                 string[] line = lines[i].Split(';');
 
-                int year = Convert.ToInt32(line[2].Substring(0, 4));
-                int month = Convert.ToInt32(line[2].Substring(4, 2));
-                int day = Convert.ToInt32(line[2].Substring(6, 2));
-
-                int hour = Convert.ToInt32(line[3].Substring(0, 2));
-                int minute = Convert.ToInt32(line[3].Substring(2, 2));
-                int second = Convert.ToInt32(line[3].Substring(4, 2));
-
-                DateTime  timeStart = new DateTime(year, month, day, hour, minute, second);
+                DateTime timeStart = DateTimeParseHelper.ParseFromTwoStrings(line[2], line[3]);
 
                 Candle candle = new Candle();
                 candle.Open = line[4].ToDecimal();
@@ -497,15 +488,7 @@ namespace OsEngine.Market.Servers.MFD
 
                 string[] line = lines[i].Split(';');
 
-                int year = Convert.ToInt32(line[2].Substring(0, 4));
-                int month = Convert.ToInt32(line[2].Substring(4, 2));
-                int day = Convert.ToInt32(line[2].Substring(6, 2));
-
-                int hour = Convert.ToInt32(line[3].Substring(0, 2));
-                int minute = Convert.ToInt32(line[3].Substring(2, 2));
-                int second = Convert.ToInt32(line[3].Substring(4, 2));
-
-                DateTime timeStart = new DateTime(year, month, day, hour, minute, second);
+                DateTime timeStart = DateTimeParseHelper.ParseFromTwoStrings(line[2], line[3]);
 
                 Trade trade = new Trade();
                 trade.Price = line[4].ToDecimal();

--- a/project/OsEngine/OsEngine.csproj
+++ b/project/OsEngine/OsEngine.csproj
@@ -447,6 +447,7 @@
     <Compile Include="Entity\ProxyHolderAddUi.xaml.cs">
       <DependentUpon>ProxyHolderAddUi.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\DateTimeParseHelper.cs" />
     <Compile Include="Logging\ServerTelegram.cs" />
     <Compile Include="Logging\ServerTelegramUi.xaml.cs">
       <DependentUpon>ServerTelegramUi.xaml</DependentUpon>
@@ -1942,7 +1943,6 @@
     <Resource Include="Images\MainWIndow\alor1.png" />
     <Resource Include="Images\MainWIndow\alor2.png" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Grpc.Core.2.46.6\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.2.46.6\build\net45\Grpc.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
в два раза быстрее, судя по бенчмарку. ускорит загрузку больших объемов свечей, трейдов истории и прочего подобного

```
public class DateTimeParseBenchmark
    {
        private string DateTimeString = "20241231,235959";

        [Benchmark]
        public DateTime ByStrings()
        {
            string[] sIn = DateTimeString.Split(',');

            int year = Convert.ToInt32(sIn[0].Substring(0, 4));
            int month = Convert.ToInt32(sIn[0].Substring(4, 2));
            int day = Convert.ToInt32(sIn[0].Substring(6, 2));

            int hour = Convert.ToInt32(sIn[1].Substring(0, 2));
            int minute = Convert.ToInt32(sIn[1].Substring(2, 2));
            int second = Convert.ToInt32(sIn[1].Substring(4, 2));
            
            return new DateTime(year, month, day, hour, minute, second);
        }
        
        [Benchmark]
        public DateTime ByInts()
        {
            string[] sIn = DateTimeString.Split(',');

            int dateInt = Convert.ToInt32(sIn[0].Substring(0, 8));
            int year = dateInt / 10000;
            int month = dateInt / 100 % 100;
            int day = dateInt % 100;

            int timeInt = Convert.ToInt32(sIn[1].Substring(0, 6));
            int hour = timeInt / 10000;
            int minute = timeInt / 100 % 100;
            int second = timeInt % 100;
            
            return new DateTime(year, month, day, hour, minute, second);
        }
    }
    
    internal class Program
    {
        public static void Main(string[] args)
        {
            BenchmarkRunner.Run<DateTimeParseBenchmark>();
        }
    }

```

| Method    | Mean     | Error   | StdDev  |
|---------- |---------:|--------:|--------:|
| ByStrings | 528.7 ns | 2.87 ns | 2.54 ns |
| ByInts    | 274.1 ns | 1.66 ns | 1.55 ns |
