### PR TITLE
Исправил опечатку в LowerOrEqual

### DIFF
--- a/project/OsEngine/Entity/PositionOpenerToStop.cs
+++ b/project/OsEngine/Entity/PositionOpenerToStop.cs
@@ -157,7 +157,14 @@ namespace OsEngine.Entity
         /// <summary>
         /// activate when the price is lower or equal 
         /// </summary>
-        LowerOrEqyal
+        LowerOrEqual = 2,
+        
+        /// <summary>
+        /// activate when the price is lower or equal.
+        /// Left for backwards compatibility with typo
+        /// </summary>
+        [Obsolete("Typo. Use LowerOrEqual instead.")]
+        LowerOrEqyal = 2,
     }
 
     public enum PositionOpenerToStopLifeTimeType

--- a/project/OsEngine/OsTrader/Panels/Tab/BotTabSimple.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/BotTabSimple.cs
@@ -4880,7 +4880,7 @@ namespace OsEngine.OsTrader.Panels.Tab
                     if ((PositionOpenerToStop[i].ActivateType == StopActivateType.HigherOrEqual &&
                          price >= PositionOpenerToStop[i].PriceRedLine)
                         ||
-                        (PositionOpenerToStop[i].ActivateType == StopActivateType.LowerOrEqyal &&
+                        (PositionOpenerToStop[i].ActivateType == StopActivateType.LowerOrEqual &&
                          price <= PositionOpenerToStop[i].PriceRedLine))
                     {
                         if (PositionOpenerToStop[i].Side == Side.Buy)

--- a/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionOpenUi2.xaml.cs
+++ b/project/OsEngine/OsTrader/Panels/Tab/Internal/PositionOpenUi2.xaml.cs
@@ -46,7 +46,7 @@ namespace OsEngine.OsTrader.Panels.Tab.Internal
             LabelStopActivationPrice.Content = OsLocalization.Trader.Label206;
             LabelStopActivationType.Content = OsLocalization.Trader.Label207;
 
-            ComboBoxStopLimitType.Items.Add(StopActivateType.LowerOrEqyal.ToString());
+            ComboBoxStopLimitType.Items.Add(StopActivateType.LowerOrEqual.ToString());
             ComboBoxStopLimitType.Items.Add(StopActivateType.HigherOrEqual.ToString());
             ComboBoxStopLimitType.SelectedItem = StopActivateType.HigherOrEqual.ToString();
 

--- a/project/OsEngine/Robots/OnScriptIndicators/PriceChannelVolatility.cs
+++ b/project/OsEngine/Robots/OnScriptIndicators/PriceChannelVolatility.cs
@@ -229,7 +229,7 @@ public class PriceChannelVolatility : BotPanel
                 decimal priceEnter = _lastPcDown;
                 _tab.SellAtStop(VolumeFix1.ValueDecimal,
                     priceEnter - Slippage.ValueInt * _tab.Securiti.PriceStep,
-                    priceEnter, StopActivateType.LowerOrEqyal);
+                    priceEnter, StopActivateType.LowerOrEqual);
             }
             return;
         }
@@ -250,7 +250,7 @@ public class PriceChannelVolatility : BotPanel
                 decimal priceEnter = _lastPcDown - (_lastAtr * KofAtr.ValueDecimal);
                 _tab.SellAtStop(VolumeFix2.ValueDecimal,
                     priceEnter - Slippage.ValueInt * _tab.Securiti.PriceStep,
-                    priceEnter, StopActivateType.LowerOrEqyal);
+                    priceEnter, StopActivateType.LowerOrEqual);
             }
         }
     }

--- a/project/OsEngine/Robots/PositionsMicromanagement/EnvelopsCountertrend.cs
+++ b/project/OsEngine/Robots/PositionsMicromanagement/EnvelopsCountertrend.cs
@@ -181,7 +181,7 @@ namespace OsEngine.Robots.PositionsMicromanagement
                 {
                     nextEntryPrice = firstPosEntryPrice - firstPosEntryPrice * (AveragingOnePercent.ValueDecimal / 100);
                     _tab.BuyAtStopMarket(GetVolume(_tab), nextEntryPrice, nextEntryPrice, 
-                        StopActivateType.LowerOrEqyal, 1, "", PositionOpenerToStopLifeTimeType.CandlesCount);
+                        StopActivateType.LowerOrEqual, 1, "", PositionOpenerToStopLifeTimeType.CandlesCount);
                 }
                 else if (positions[0].Direction == Side.Sell)
                 {
@@ -203,7 +203,7 @@ namespace OsEngine.Robots.PositionsMicromanagement
                 {
                     nextEntryPrice = firstPosEntryPrice - firstPosEntryPrice * (AveragingTwoPercent.ValueDecimal / 100);
                     _tab.BuyAtStopMarket(GetVolume(_tab), nextEntryPrice, nextEntryPrice, 
-                        StopActivateType.LowerOrEqyal, 1, "", PositionOpenerToStopLifeTimeType.CandlesCount);
+                        StopActivateType.LowerOrEqual, 1, "", PositionOpenerToStopLifeTimeType.CandlesCount);
                 }
                 else if (positions[0].Direction == Side.Sell)
                 {

--- a/project/OsEngine/Robots/Trend/EnvelopTrend.cs
+++ b/project/OsEngine/Robots/Trend/EnvelopTrend.cs
@@ -155,7 +155,7 @@ namespace OsEngine.Robots.Trend
                      _envelop.ValuesDown[_envelop.ValuesDown.Count - 1] -
                      Slippage.ValueInt * _tab.Securiti.PriceStep,
                     _envelop.ValuesDown[_envelop.ValuesDown.Count - 1],
-                    StopActivateType.LowerOrEqyal, 1);
+                    StopActivateType.LowerOrEqual, 1);
             }
             else
             { // trail stop logic


### PR DESCRIPTION
При этом чтобы у ни у кого не сломались старые роботы оставил старое значение с опечаткой.
Пометил его как устаревшее.
Поэтому пользователь получит предупреждение:
warning CS0618: 'Greeter.StopActivateType.LowerOrEqyal' is obsolete: 'Typo. Use LowerOrEqual instead.'

При этом можно использовать как с опечаткой так и без.