### PR TITLE
Обновления коннектора Алор для соответствия стандартам тестов коннекторов

### DIFF
--- a/project/OsEngine/Robots/AutoTestBots/ServerTests/Data_1_Integrity.cs
+++ b/project/OsEngine/Robots/AutoTestBots/ServerTests/Data_1_Integrity.cs
@@ -59,9 +59,7 @@ namespace OsEngine.Robots.AutoTestBots.ServerTests
             //6.1.3.Дата старта запроса должна совпадать с данными первых свечей, если данные точно есть.
             //6.1.4.Дата конца запроса должна совпадать с данными последней свечи, если данные точно есть.
 
-            DateTime lastMidnightTime = StartDate.Date;
-
-            lastMidnightTime = lastMidnightTime + new TimeSpan(0, 0, 1, 1); // 1 минута и 1 секунда
+            DateTime lastMidnightTime = StartDate.Date + new TimeSpan(0, 0, 1, 1); // 1 минута и 1 секунда
 
             DateTime startTime = lastMidnightTime.AddDays(-3);
             DateTime endTime = lastMidnightTime.AddDays(-1).AddHours(-1);

--- a/project/OsEngine/Robots/AutoTestBots/ServerTests/Orders_8_RequestOnReconnect.cs
+++ b/project/OsEngine/Robots/AutoTestBots/ServerTests/Orders_8_RequestOnReconnect.cs
@@ -296,7 +296,7 @@ namespace OsEngine.Robots.AutoTestBots.ServerTests
         {
             if (order.State == OrderStateType.None)
             {
-                this.SetNewError("Error 12. Order whith state NONE");
+                this.SetNewError("Error 12. Order with state NONE");
                 return;
             }
 
@@ -350,7 +350,7 @@ namespace OsEngine.Robots.AutoTestBots.ServerTests
 
             if (order.TypeOrder != OrderPriceType.Limit)
             {
-                this.SetNewError("Error 13. Order Type is note Liimt. Real type: " + order.TypeOrder);
+                this.SetNewError("Error 13. Order Type is not Limit. Real type: " + order.TypeOrder);
                 return false;
             }
 


### PR DESCRIPTION
- исправил параметры запросов (там Алор их немного обновил и обозначил старые как deprecated)
- добавил guid к запросам, чтобы можно было с нескольких терминалов одновременно подключаться
- исправил небольшой косячек с конвертацией в UTC - там в паре мест не было это явно указано и создавалось в локальной зоне.
- фильтранул лишние данные при запросах свечей (влияет только на корректность теста)
- исправил несколько private переменных - добавил _
