### PR TITLE
Speed-up sort of "optmization results"

### DIFF
--- a/project/OsEngine/OsOptimizer/OptimizerReport.cs
+++ b/project/OsEngine/OsOptimizer/OptimizerReport.cs
@@ -51,6 +51,85 @@ namespace OsEngine.OsOptimizer
 
         }
 
+        public static void SortResults(List<OptimizerReport> reports, SortBotsType sortType)
+        {
+            if (reports ==  null || reports.Count == 0) 
+            { 
+                return; 
+            }
+
+            if (sortType == SortBotsType.BotName)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return Convert.ToInt32(rep1.BotName.Split(' ')[0]).CompareTo(Convert.ToInt32(rep2.BotName.Split(' ')[0]));
+                });
+            }
+            else if (sortType == SortBotsType.TotalProfit)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.TotalProfit.CompareTo(rep1.TotalProfit);
+                });
+            }
+            else if (sortType == SortBotsType.PositionCount)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.PositionsCount.CompareTo(rep1.PositionsCount);
+                });
+            }
+            else if (sortType == SortBotsType.MaxDrowDawn)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.MaxDrowDawn.CompareTo(rep1.MaxDrowDawn);
+                });
+            }
+            else if (sortType == SortBotsType.AverageProfit)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.AverageProfit.CompareTo(rep1.AverageProfit);
+                });
+            }
+            else if (sortType == SortBotsType.AverageProfitPercent)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.AverageProfitPercentOneContract.CompareTo(rep1.AverageProfitPercentOneContract);
+                });
+            }
+            else if (sortType == SortBotsType.ProfitFactor)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.ProfitFactor.CompareTo(rep1.ProfitFactor);
+                });
+            }
+            else if (sortType == SortBotsType.PayOffRatio)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.PayOffRatio.CompareTo(rep1.PayOffRatio);
+                });
+            }
+            else if (sortType == SortBotsType.Recovery)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.Recovery.CompareTo(rep1.Recovery);
+                });
+            }
+            else if (sortType == SortBotsType.SharpRatio)
+            {
+                reports.Sort(delegate (OptimizerReport rep1, OptimizerReport rep2)
+                {
+                    return rep2.SharpRatio.CompareTo(rep1.SharpRatio);
+                });
+            }
+        }
+
     }
 
     public class OptimizerReport

--- a/project/OsEngine/OsOptimizer/OptimizerReportCharting.cs
+++ b/project/OsEngine/OsOptimizer/OptimizerReportCharting.cs
@@ -155,7 +155,7 @@ namespace OsEngine.OsOptimizer
 
                 for (int i = 0; i < reports.Count; i++)
                 {
-                    SortResults(reports[i].Reports);
+                    OptimazerFazeReport.SortResults(reports[i].Reports, _sortBotsType);
                 }
 
                 GetBestBotNum(reports[0].Reports);
@@ -169,23 +169,6 @@ namespace OsEngine.OsOptimizer
             catch (Exception e)
             {
                 SendLogMessage(e.ToString(), LogMessageType.Error);
-            }
-        }
-
-        private void SortResults(List<OptimizerReport> reports)
-        {
-            for (int i = 0; i < reports.Count; i++)
-            {
-                for (int i2 = 0; i2 < reports.Count - 1; i2++)
-                {
-                    if (FirstLessSecond(reports[i2], reports[i2 + 1], _sortBotsType))
-                    {
-                        // сортировка пузыриком // фаталити
-                        OptimizerReport glass = reports[i2];
-                        reports[i2] = reports[i2 + 1];
-                        reports[i2 + 1] = glass;
-                    }
-                }
             }
         }
 
@@ -208,57 +191,6 @@ namespace OsEngine.OsOptimizer
                 _sortBotNumber = reports.Count - 1;
             }
         }
-
-        private bool FirstLessSecond(OptimizerReport rep1, OptimizerReport rep2, SortBotsType sortType)
-        {
-            if (sortType == SortBotsType.TotalProfit &&
-                rep1.TotalProfit < rep2.TotalProfit)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.PositionCount &&
-                     rep1.PositionsCount < rep2.PositionsCount)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.MaxDrowDawn &&
-                     rep1.MaxDrowDawn < rep2.MaxDrowDawn)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.AverageProfit &&
-                     rep1.AverageProfit < rep2.AverageProfit)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.AverageProfitPercent &&
-                     rep1.AverageProfitPercentOneContract < rep2.AverageProfitPercentOneContract)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.ProfitFactor &&
-                     rep1.ProfitFactor < rep2.ProfitFactor)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.PayOffRatio &&
-                     rep1.PayOffRatio < rep2.PayOffRatio)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.Recovery &&
-                     rep1.Recovery < rep2.Recovery)
-            {
-                return true;
-            }
-             else if (sortType == SortBotsType.SharpRatio &&
-                     rep1.SharpRatio < rep2.SharpRatio)
-            {
-                return true;
-            }
-
-            return false;
-        } 
 
         private SortBotsType _sortBotsType;
 

--- a/project/OsEngine/OsOptimizer/OptimizerReportUi.xaml.cs
+++ b/project/OsEngine/OsOptimizer/OptimizerReportUi.xaml.cs
@@ -99,7 +99,7 @@ namespace OsEngine.OsOptimizer
             {
                 for (int i = 0; i < _reports.Count; i++)
                 {
-                    SortResults(_reports[i].Reports);
+                    OptimazerFazeReport.SortResults(_reports[i].Reports, _sortBotsType);
                 }
 
                 PaintTableFazes();
@@ -572,79 +572,6 @@ namespace OsEngine.OsOptimizer
             _gridResults.CellMouseClick += _gridResults_CellMouseClick;
         }
 
-        private void SortResults(List<OptimizerReport> reports)
-        {
-            for (int i = 0; i < reports.Count; i++)
-            {
-                for (int i2 = 0; i2 < reports.Count - 1; i2++)
-                {
-                    if (FirstLessSecond(reports[i2], reports[i2 + 1], _sortBotsType))
-                    {
-                        // сортировка пузыриком // фаталити https://youtu.be/LOh_J0Dah7c?t=30
-                        OptimizerReport glass = reports[i2];
-                        reports[i2] = reports[i2 + 1];
-                        reports[i2 + 1] = glass;
-                    }
-                }
-            }
-        }
-
-        private bool FirstLessSecond(OptimizerReport rep1, OptimizerReport rep2, SortBotsType sortType)
-        {
-            if (sortType == SortBotsType.BotName &&
-            Convert.ToInt32(rep1.BotName.Split(' ')[0]) > Convert.ToInt32(rep2.BotName.Split(' ')[0]))
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.TotalProfit &&
-                rep1.TotalProfit < rep2.TotalProfit)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.PositionCount &&
-                     rep1.PositionsCount < rep2.PositionsCount)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.MaxDrowDawn &&
-                     rep1.MaxDrowDawn < rep2.MaxDrowDawn)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.AverageProfit &&
-                     rep1.AverageProfit < rep2.AverageProfit)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.AverageProfitPercent &&
-                     rep1.AverageProfitPercentOneContract < rep2.AverageProfitPercentOneContract)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.ProfitFactor &&
-                     rep1.ProfitFactor < rep2.ProfitFactor)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.PayOffRatio &&
-                     rep1.PayOffRatio < rep2.PayOffRatio)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.Recovery &&
-                     rep1.Recovery < rep2.Recovery)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.SharpRatio &&
-                     rep1.SharpRatio < rep2.SharpRatio)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         private DataGridViewRow GetRowResult(OptimizerReportTab report)
         {
             DataGridViewRow row = new DataGridViewRow();
@@ -847,7 +774,7 @@ namespace OsEngine.OsOptimizer
             {
                 for (int i = 0; i < _reports.Count; i++)
                 {
-                    SortResults(_reports[i].Reports);
+                    OptimazerFazeReport.SortResults(_reports[i].Reports, _sortBotsType);
                 }
 
                 PaintTableResults();

--- a/project/OsEngine/OsOptimizer/OptimizerUi.xaml.cs
+++ b/project/OsEngine/OsOptimizer/OptimizerUi.xaml.cs
@@ -327,7 +327,7 @@ namespace OsEngine.OsOptimizer
 
                 for (int i = 0; i < _reports.Count; i++)
                 {
-                    SortResults(_reports[i].Reports);
+                    OptimazerFazeReport.SortResults(_reports[i].Reports, _sortBotsType);
                 }
 
                 PaintEndOnAllProgressBars();
@@ -3004,79 +3004,6 @@ namespace OsEngine.OsOptimizer
             _gridResults.CellMouseClick += _gridResults_CellMouseClick;
         }
 
-        private void SortResults(List<OptimizerReport> reports)
-        {
-            for (int i = 0; i < reports.Count; i++)
-            {
-                for (int i2 = 0; i2 < reports.Count - 1; i2++)
-                {
-                    if (FirstLessSecond(reports[i2], reports[i2 + 1], _sortBotsType))
-                    {
-                        // сортировка пузыриком // фаталити https://youtu.be/LOh_J0Dah7c?t=30
-                        OptimizerReport glass = reports[i2];
-                        reports[i2] = reports[i2 + 1];
-                        reports[i2 + 1] = glass;
-                    }
-                }
-            }
-        }
-
-        private bool FirstLessSecond(OptimizerReport rep1, OptimizerReport rep2, SortBotsType sortType)
-        {
-            if (sortType == SortBotsType.BotName &&
-            Convert.ToInt32(rep1.BotName.Split(' ')[0]) > Convert.ToInt32(rep2.BotName.Split(' ')[0]))
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.TotalProfit &&
-                rep1.TotalProfit < rep2.TotalProfit)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.PositionCount &&
-                     rep1.PositionsCount < rep2.PositionsCount)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.MaxDrowDawn &&
-                     rep1.MaxDrowDawn < rep2.MaxDrowDawn)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.AverageProfit &&
-                     rep1.AverageProfit < rep2.AverageProfit)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.AverageProfitPercent &&
-                     rep1.AverageProfitPercentOneContract < rep2.AverageProfitPercentOneContract)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.ProfitFactor &&
-                     rep1.ProfitFactor < rep2.ProfitFactor)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.PayOffRatio &&
-                     rep1.PayOffRatio < rep2.PayOffRatio)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.Recovery &&
-                     rep1.Recovery < rep2.Recovery)
-            {
-                return true;
-            }
-            else if (sortType == SortBotsType.SharpRatio &&
-                     rep1.SharpRatio < rep2.SharpRatio)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         private DataGridViewRow GetRowResult(OptimizerReportTab report)
         {
             DataGridViewRow row = new DataGridViewRow();
@@ -3279,7 +3206,7 @@ namespace OsEngine.OsOptimizer
             {
                 for (int i = 0; i < _reports.Count; i++)
                 {
-                    SortResults(_reports[i].Reports);
+                    OptimazerFazeReport.SortResults(_reports[i].Reports, _sortBotsType);
                 }
 
                 PaintTableResults();


### PR DESCRIPTION
- use sort O(N*log(N)) instead of O(N*N) - huge speedup on big amound of results
- optimize comparison functions
- use one functions in all places (removed copy-paste)