### PR TITLE
Запоминать состояние чекбокса "Processing Command from Telegram"

### DIFF
--- a/project/OsEngine/Logging/ServerTelegram.cs
+++ b/project/OsEngine/Logging/ServerTelegram.cs
@@ -328,7 +328,8 @@ namespace OsEngine.Logging
                     BotToken = reader.ReadLine();
                     ChatId = Convert.ToInt64(reader.ReadLine());
 
-                    if (reader.ReadLine() == "true")
+                    string isProcessingCommand = reader.ReadLine();
+                    if ( isProcessingCommand == "True" || isProcessingCommand == "true")
                     {
                         ProcessingCommand = true;
                     }


### PR DESCRIPTION
Fix Запоминать состояние чекбокса "Processing Command from Telegram".

Не работает сохранение состояния чекбокса "Processing Command from Telegram".

Настройка не сохраняется, при каждом запуске платформы необходимо активировать чекбокс заново.