### PR TITLE
Alor, TInvest: new parameter to ignore trades coming from morning opening auction

### DIFF
--- a/project/OsEngine/Market/Servers/TInvest/TInvestServer.cs
+++ b/project/OsEngine/Market/Servers/TInvest/TInvestServer.cs
@@ -1663,6 +1663,24 @@ namespace OsEngine.Market.Servers.TInvest
                         trade.Side = marketDataResponse.Trade.Direction == TradeDirection.Buy ? Side.Buy : Side.Sell;
                         trade.Volume = marketDataResponse.Trade.Quantity;
 
+                        if (_ignoreMorningAuctionTrades && DateTime.Now.Hour < 9) // process only mornings
+                        {
+                            if (security.SecurityType == SecurityType.Futures)
+                            {
+                                if (trade.Time < DateTime.Today.AddHours(9))
+                                {
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                if (trade.Time < DateTime.Today.AddHours(7))
+                                {
+                                    continue;
+                                }
+                            }
+                        }
+
                         if (NewTradesEvent != null)
                         {
                             NewTradesEvent(trade);

--- a/project/OsEngine/Market/Servers/TInvest/TInvestServer.cs
+++ b/project/OsEngine/Market/Servers/TInvest/TInvestServer.cs
@@ -37,6 +37,7 @@ namespace OsEngine.Market.Servers.TInvest
             CreateParameterBoolean(OsLocalization.Market.UseOther, false);
             CreateParameterBoolean("Filter out non-market data (holiday trading)", true);
             CreateParameterBoolean("Filter out dealer trades", false);
+            CreateParameterBoolean("Ignore morning auction trades", true);
         }
     }
 
@@ -88,6 +89,7 @@ namespace OsEngine.Market.Servers.TInvest
                 _accessToken = ((ServerParameterPassword)ServerParameters[0]).Value;
                 _filterOutNonMarketData = ((ServerParameterBool)ServerParameters[5]).Value;
                 _filterOutDealerTrades = ((ServerParameterBool)ServerParameters[6]).Value;
+                _ignoreMorningAuctionTrades = ((ServerParameterBool)ServerParameters[7]).Value;
 
                 if (string.IsNullOrEmpty(_accessToken))
                 {
@@ -290,6 +292,7 @@ namespace OsEngine.Market.Servers.TInvest
 
         private bool _filterOutNonMarketData; // отфльтровать кухню выходного дня
         private bool _filterOutDealerTrades; // отфльтровать кухонные сделки (дилерские, внутренние)
+        private bool _ignoreMorningAuctionTrades; // ignore trades before 7:00 MSK for stocks and before 9:00 for futures
         private string _accessToken;
 
         private Dictionary<string, int> _orderNumbers = new Dictionary<string, int>();


### PR DESCRIPTION
1. ignore trades < 9:00 MSK for futures and < 7:00 for stocks and others
2. Otherwise you get zero-body candle right before main trading session wich is different behaviour than in tester.
3. parameter is true by default 

![Снимок экрана 2025-04-20 233116](https://github.com/user-attachments/assets/37121c80-6407-4faf-a8cc-b339c5e57b8d)
