### PR TITLE
К конектерам BinanceSpot и BinanceFutures добавлен Shared RateGate

### DIFF
--- a/project/OsEngine/Language/MarketLocal.cs
+++ b/project/OsEngine/Language/MarketLocal.cs
@@ -1324,6 +1324,9 @@ namespace OsEngine.Language
           "Eng:Error while loading securities. The T-Investments server is not available. The connector has been restarted. Cheburnet is offline_" +
           "Ru:Ошибка при загрузке инструментов. Сервер Т-Инвестиции не доступен. Коннектор отправлен на перезапуск. Чебурнет перегружен... _");
 
+        public string Label324 => OsLocalization.ConvertToLocString(
+        "Eng:If set to True, similar servers will share a common request counter to avoid exceeding API limits_" +
+        "Ru:Если True - то аналогичные сервера будут иметь общий счетчик запросов (чтобы не выходить за пределы API лимитов)_");
 
 
 

--- a/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
+++ b/project/OsEngine/Market/Servers/Binance/Futures/BinanceServerFutures.cs
@@ -48,6 +48,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
             ServerParameters[3].ValueChange += BinanceServerFutures_ValueChange;
             CreateParameterBoolean("Demo Account", false);
             CreateParameterBoolean("Extended Data", false);
+            CreateParameterBoolean("Use Shared RateGate", false);
 
             ServerParameters[0].Comment = OsLocalization.Market.Label246;
             ServerParameters[1].Comment = OsLocalization.Market.Label247;
@@ -55,6 +56,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
             ServerParameters[3].Comment = OsLocalization.Market.Label250;
             ServerParameters[4].Comment = OsLocalization.Market.Label268;
             ServerParameters[5].Comment = OsLocalization.Market.Label270;
+            ServerParameters[6].Comment = OsLocalization.Market.Label324;
 
         }
 
@@ -1684,7 +1686,7 @@ namespace OsEngine.Market.Servers.Binance.Futures
 
                 string urlStrDepth = null;
 
-                if (((ServerParameterBool)ServerParameters[13]).Value == false)
+                if (((ServerParameterBool)ServerParameters[14]).Value == false)
                 {
                     urlStrDepth = wss_point + "/stream?streams="
                                  + security.Name.ToLower() + "@depth5"
@@ -3162,13 +3164,20 @@ namespace OsEngine.Market.Servers.Binance.Futures
 
         RateGate _rateGate = new RateGate(1, TimeSpan.FromMilliseconds(100));
 
+        private static readonly RateGate _sharedRateGate = new RateGate(1, TimeSpan.FromMilliseconds(100));
+
+        private RateGate GetRateGate()
+        {
+            return ((ServerParameterBool)ServerParameters[6]).Value ? _sharedRateGate : _rateGate;
+        }
+
         public string CreateQuery(Method method, string endpoint, Dictionary<string, string> param = null, bool auth = false)
         {
             try
             {
                 lock (_queryHttpLocker)
                 {
-                    _rateGate.WaitToProceed();
+                    GetRateGate().WaitToProceed();
                     return PerformHttpRequest(method, endpoint, param, auth);
                 }
             }

--- a/project/OsEngine/Market/Servers/Binance/Spot/BinanceServerSpot.cs
+++ b/project/OsEngine/Market/Servers/Binance/Spot/BinanceServerSpot.cs
@@ -35,10 +35,12 @@ namespace OsEngine.Market.Servers.Binance.Spot
             CreateParameterString(OsLocalization.Market.ServerParamPublicKey, "");
             CreateParameterPassword(OsLocalization.Market.ServerParameterSecretKey, "");
             CreateParameterBoolean("Extended Data", false);
+            CreateParameterBoolean("Use Shared RateGate", false);
 
             ServerParameters[0].Comment = OsLocalization.Market.Label246;
             ServerParameters[1].Comment = OsLocalization.Market.Label247;
             ServerParameters[2].Comment = OsLocalization.Market.Label269;
+            ServerParameters[3].Comment = OsLocalization.Market.Label324;
         }
     }
 
@@ -1706,7 +1708,7 @@ namespace OsEngine.Market.Servers.Binance.Spot
 
                 string urlStr = null;
 
-                if (((ServerParameterBool)ServerParameters[10]).Value == false)
+                if (((ServerParameterBool)ServerParameters[11]).Value == false)
                 {
                     urlStr = "wss://stream.binance.com:9443/stream?streams="
                                                 + security.Name.ToLower()
@@ -3156,13 +3158,20 @@ namespace OsEngine.Market.Servers.Binance.Spot
 
         private RateGate _rateGate = new RateGate(1, TimeSpan.FromMilliseconds(100));
 
+        private static readonly RateGate _sharedRateGate = new RateGate(1, TimeSpan.FromMilliseconds(100));
+
+        private RateGate GetRateGate()
+        {
+            return ((ServerParameterBool)ServerParameters[3]).Value ? _sharedRateGate : _rateGate;
+        }
+
         public string CreateQuery(BinanceExchangeType startUri, Method method, string endpoint, Dictionary<string, string> param = null, bool auth = false)
         {
             try
             {
                 lock (_queryHttpLocker)
                 {
-                    _rateGate.WaitToProceed();
+                    GetRateGate().WaitToProceed();
                     string fullUrl = "";
 
                     if (param != null)


### PR DESCRIPTION
Если не используется прокси, но используются несколько одинаковых серверов то ловим бан по количеству запросов (каждый коннектор считает только свои)

В исправлении добавлен общий счетчик, использование которого можно настроить в параметрах подключения