### PR TITLE
fix: check IsDisposed before grid Invoke in OsDataSetDetailUi

### DIFF
--- a/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
+++ b/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
@@ -177,7 +177,12 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_isDeleted)
+                {
+                    return;
+                }
+
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -200,9 +205,13 @@ namespace OsEngine.OsData
 
                 PaintTable();
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен. перерисовку останавливаем
+            }
             catch (Exception error)
             {
-                System.Windows.MessageBox.Show(error.Message);
+                ServerMaster.SendNewLogMessage(error.ToString(), Logging.LogMessageType.Error);
             }
         }
 
@@ -382,7 +391,7 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -410,9 +419,20 @@ namespace OsEngine.OsData
                     }
                 }
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен
+            }
             catch (Exception ex)
             {
-                _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                if (_loader != null)
+                {
+                    _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
+                else
+                {
+                    ServerMaster.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
             }
         }
 


### PR DESCRIPTION
Фикс краша: проверка IsDisposed перед Invoke в OsDataSetDetailUi

Источник: Краш-сценарий (агент Краш)
Сообщение: ObjectDisposedException в OsDataSetDetailUi. Фоновая перерисовка _grid.Invoke на задиспоженном контроле при закрытии окна. Появление у 46.41.*.*.

Одобрили:
- Краш — баг подтверждён (confirmed), регрессий нет
