### PR TITLE
fix: check IsDisposed before grid Invoke in OsDataSetDetailUi

### DIFF
--- a/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
+++ b/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
@@ -177,7 +177,12 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_isDeleted)
+                {
+                    return;
+                }
+
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -200,9 +205,13 @@ namespace OsEngine.OsData
 
                 PaintTable();
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен. перерисовку останавливаем
+            }
             catch (Exception error)
             {
-                System.Windows.MessageBox.Show(error.Message);
+                ServerMaster.SendNewLogMessage(error.ToString(), Logging.LogMessageType.Error);
             }
         }
 
@@ -382,7 +391,7 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -410,9 +419,20 @@ namespace OsEngine.OsData
                     }
                 }
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен
+            }
             catch (Exception ex)
             {
-                _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                if (_loader != null)
+                {
+                    _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
+                else
+                {
+                    ServerMaster.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
             }
         }
 


### PR DESCRIPTION
fix: check IsDisposed before grid Invoke in OsDataSetDetailUi

Источник: Краш-сценарий (задание 028a3679), повтор по добру человека
Ошибка: ObjectDisposedException в OsDataSetDetailUi — обращение к _grid (DataGridView) после Dispose при закрытии окна.

Диагностика: подтверждён по стек-трейсу из краш-отчёта + статическим анализом кода. Отдельный тест-стенд не требовался.

Изменения: project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs — добавлена проверка _isDeleted и _grid.IsDisposed перед Invoke, обработка ObjectDisposedException, безопасное логирование при _loader == null.

Одобрили:
- Фиксер — подтвердил ObjectDisposedException по стек-трейсу и статическим анализом, сборка чистая (0 ошибок)
- остальные: нет