### PR TITLE
fix: ObjectDisposedException в OsDataSetDetailUi.RePaintAll

### DIFF
--- a/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
+++ b/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
@@ -177,7 +177,12 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_isDeleted)
+                {
+                    return;
+                }
+
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -200,9 +205,13 @@ namespace OsEngine.OsData
 
                 PaintTable();
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен. перерисовку останавливаем
+            }
             catch (Exception error)
             {
-                System.Windows.MessageBox.Show(error.Message);
+                ServerMaster.SendNewLogMessage(error.ToString(), Logging.LogMessageType.Error);
             }
         }
 
@@ -382,7 +391,7 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -410,9 +419,20 @@ namespace OsEngine.OsData
                     }
                 }
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен
+            }
             catch (Exception ex)
             {
-                _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                if (_loader != null)
+                {
+                    _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
+                else
+                {
+                    ServerMaster.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
             }
         }
 


### PR DESCRIPTION
fix: ObjectDisposedException в OsDataSetDetailUi.RePaintAll

Источник: Краш-сценарий (краш-отчёт #14, OsEngine 2.0.1.8)
Ошибка: В OsDataSetDetailUi.RePaintAll (и смежной отрисовке таблицы) при закрытом окне происходило обращение к уже задиспоженному контролу _grid, что давало ObjectDisposedException. Исключение перехватывалось, но не обрабатывалось корректно (показывался MessageBox / обращение к _loader без null-проверки).

Диагностика: статический анализ кода — в методах отрисовки OsDataSetDetailUi.xaml.cs обращение к _grid.Invoke без проверки _grid.IsDisposed, плюс обработка через MessageBox.Show вместо лога, плюс разыменование _loader без проверки на null. Сборка чистая.

Изменения: project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs — добавлена проверка _isDeleted и _grid.IsDisposed перед отрисовкой, отдельный перехват ObjectDisposedException, замена MessageBox на лог (ServerMaster.SendNewLogMessage), null-проверка _loader.

Одобрили:
- Фиксер — подтвердил отсутствием проверки IsDisposed в коде и чистой сборкой
- остальные: нет