### PR TITLE
fix: NullReferenceException в OptimizerExecutor.CreateNewServer

### DIFF
--- a/project/OsEngine/OsOptimizer/OptimizerExecutor.cs
+++ b/project/OsEngine/OsOptimizer/OptimizerExecutor.cs
@@ -866,12 +866,30 @@ namespace OsEngine.OsOptimizer
             server.TypeTesterData = _master.Storage.TypeTesterData;
             server.TestingProgressChangeEvent += server_TestingProgressChangeEvent;
 
+            if (_master.BotToTest == null)
+            {
+                SendLogMessage("Optimizer. Bot to test is null. Data sources skipped", LogMessageType.Error);
+                return server;
+            }
+
             List<IIBotTab> sources = _master.BotToTest.GetTabs();
+
+            if (sources == null)
+            {
+                SendLogMessage("Optimizer. Data sources list is null. Sources skipped", LogMessageType.Error);
+                return server;
+            }
 
             for (int i = 0; i < sources.Count; i++)
             {
                 try
                 {
+                    if (sources[i] == null)
+                    {
+                        SendLogMessage("Optimizer. Bot tab is null. Source skipped", LogMessageType.Error);
+                        continue;
+                    }
+
                     if (sources[i].TabType == BotTabType.Simple)
                     {// BotTabSimple
                         BotTabSimple simple = (BotTabSimple)sources[i];
@@ -884,6 +902,12 @@ namespace OsEngine.OsOptimizer
 
                         Security secToStart =
                         _master.Storage.Securities.Find(s => s.Name == simple.Connector.SecurityName);
+
+                        if (secToStart == null)
+                        {
+                            SendLogMessage("Optimizer. Security not found in storage. Source skipped", LogMessageType.Error);
+                            continue;
+                        }
 
                         server.GetDataToSecurity(secToStart, simple.Connector.TimeFrame, report.Faze.TimeStart,
                             report.Faze.TimeEnd);
@@ -903,6 +927,12 @@ namespace OsEngine.OsOptimizer
                             Security secToStart =
                               _master.Storage.Securities.Find(s => s.Name == index.Tabs[i2].SecurityName);
 
+                            if (secToStart == null)
+                            {
+                                SendLogMessage("Optimizer. Security not found in storage. Source skipped", LogMessageType.Error);
+                                continue;
+                            }
+
                             server.GetDataToSecurity(secToStart, index.Tabs[i2].TimeFrame, report.Faze.TimeStart,
                                 report.Faze.TimeEnd);
                         }
@@ -913,6 +943,12 @@ namespace OsEngine.OsOptimizer
 
                         for (int i2 = 0; i2 < screener.Tabs.Count; i2++)
                         {
+                            if (screener.Tabs[i2] == null)
+                            {
+                                SendLogMessage("Optimizer. Screener tab is null. Source skipped", LogMessageType.Error);
+                                continue;
+                            }
+
                             if (screener.Tabs[i2].Connector == null)
                             {
                                 SendLogMessage("Optimizer. Screener tab without connector. Source skipped", LogMessageType.Error);
@@ -921,6 +957,12 @@ namespace OsEngine.OsOptimizer
 
                             Security secToStart =
                               _master.Storage.Securities.Find(s => s.Name == screener.Tabs[i2].Connector.SecurityName);
+
+                            if (secToStart == null)
+                            {
+                                SendLogMessage("Optimizer. Security not found in storage. Source skipped", LogMessageType.Error);
+                                continue;
+                            }
 
                             server.GetDataToSecurity(secToStart, screener.Tabs[i2].Connector.TimeFrame, report.Faze.TimeStart,
                                 report.Faze.TimeEnd);


### PR DESCRIPTION
Источник: Краш (краш-сервер, ошибка #18)

Ошибка: NullReferenceException в OsOptimizer.OptimizerExecutor.CreateNewServer при запуске оптимизатора. Метод обращается к _master.BotToTest.GetTabs(), затем к источникам данных (вкладкам) и Security в _master.Storage.Securities без проверки на null. Если бот или вкладка отсутствует/равна null, либо инструмент не найден в хранилище — NRE и падение оптимизации.

Диагностика: подтверждён по краш-отчёту установки; воспроизводится при запуске оптимизации с неполными/битыми данными. Статический анализ CreateNewServer: отсутствие null-проверок перед GetDataToSecurity.

Изменения: project/OsEngine/OsOptimizer/OptimizerExecutor.cs — добавлены null-проверки _master.BotToTest, списка sources, отдельных вкладок (sources[i], screener.Tabs[i2]) и найденного Security перед GetDataToSecurity, с логированием пропуска источника.

Одобрили:
- Фиксер — подтвердил по краш-отчёту и статическому анализу кода; сборка чистая
- остальные: нет
