### PR TITLE
fix: ObjectDisposedException в OsDataSetDetailUi.RePaintAll

### DIFF
--- a/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
+++ b/project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs
@@ -177,7 +177,12 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_isDeleted)
+                {
+                    return;
+                }
+
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -200,9 +205,13 @@ namespace OsEngine.OsData
 
                 PaintTable();
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен. перерисовку останавливаем
+            }
             catch (Exception error)
             {
-                System.Windows.MessageBox.Show(error.Message);
+                ServerMaster.SendNewLogMessage(error.ToString(), Logging.LogMessageType.Error);
             }
         }
 
@@ -382,7 +391,7 @@ namespace OsEngine.OsData
         {
             try
             {
-                if (_grid == null)
+                if (_grid == null || _grid.IsDisposed)
                 {
                     return;
                 }
@@ -410,9 +419,20 @@ namespace OsEngine.OsData
                     }
                 }
             }
+            catch (ObjectDisposedException)
+            {
+                // окно закрыто, контрол задиспожен
+            }
             catch (Exception ex)
             {
-                _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                if (_loader != null)
+                {
+                    _loader.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
+                else
+                {
+                    ServerMaster.SendNewLogMessage(ex.ToString(), Logging.LogMessageType.Error);
+                }
             }
         }
 


### PR DESCRIPTION
Источник: Краш (краш-сервер, ошибка #14)

Ошибка: ObjectDisposedException в OsData.OsDataSetDetailUi.RePaintAll при перерисовке грида после закрытия окна. Код обращается к уже задиспоженному _grid без проверки IsDisposed и без отлова ObjectDisposedException, из-за чего перерисовка падает.

Диагностика: подтверждён по краш-отчёту установки; статический анализ RePaintAll — отсутствие проверки IsDisposed и отлова ObjectDisposedException.

Изменения: project/OsEngine/OsData/OsDataSetDetailUi.xaml.cs — добавлены проверки _isDeleted и _grid.IsDisposed, отлов ObjectDisposedException, замена MessageBox.Show на логирование через ServerMaster, null-проверка _loader.

Одобрили:
- Фиксер — подтвердил по краш-отчёту и статическому анализу кода; сборка чистая
- остальные: нет
