### PR TITLE
fix: перехват исключений UI-потока (WPF/WinForms) и логирование первичного исключения

### DIFF
--- a/project/OsEngine/MainWindow.xaml.cs
+++ b/project/OsEngine/MainWindow.xaml.cs
@@ -65,6 +65,14 @@ namespace OsEngine
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
+            // WinForms: принудительно ловим исключения UI-потока, чтобы WinForms не показывал
+            // свой ThreadExceptionDialog поверх WPF-окна (вложенный модальный цикл -> фатальный вторичный throw)
+            System.Windows.Forms.Application.SetUnhandledExceptionMode(System.Windows.Forms.UnhandledExceptionMode.CatchException);
+            System.Windows.Forms.Application.ThreadException += WinForms_ThreadException;
+
+            // WPF: перехватываем исключения UI-потока и логируем первичное исключение
+            System.Windows.Application.Current.DispatcherUnhandledException += App_DispatcherUnhandledException;
+
             this.Closing += MainWindow_Closing;
 
             RePaintThemeImages();
@@ -326,6 +334,40 @@ namespace OsEngine
             else
             {
                 MessageBox.Show(message);
+            }
+        }
+
+        void WinForms_ThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            LogUiThreadException(e.Exception);
+        }
+
+        void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            LogUiThreadException(e.Exception);
+            e.Handled = true;
+        }
+
+        void LogUiThreadException(Exception exception)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            string message = OsLocalization.MainWindow.Message5 + " UI THREAD " + exception;
+
+            message = _startProgram + "  " + message;
+
+            message = System.Reflection.Assembly.GetExecutingAssembly() + "\n" + message;
+
+            _messageToCrashServer = "Crash% " + message;
+            Thread worker = new Thread(SendMessageInCrashServer);
+            worker.Start();
+
+            if (ServerMaster.Log != null)
+            {
+                ServerMaster.Log.ProcessMessage(message, Logging.LogMessageType.Error);
             }
         }
 


### PR DESCRIPTION
Что за баг: OsEngine — гибрид WPF + WinForms (WinForms-контролы встроены через WindowsFormsHost). При необработанном исключении на UI-потоке WinForms показывал свой ThreadExceptionDialog (модальный WinForms-диалог), который запускал вложенный цикл сообщений поверх WPF-цикла диспетчера. Вложенные модальные циклы конфликтовали — вторичный throw System.InvalidOperationException в MS.Win32.HwndWrapper.WndProc. Первичное исключение (настоящая причина) терялось: в отчёт попадал только вторичный throw.

Что сделано: в project/OsEngine/MainWindow.xaml.cs добавлены:
- Application.SetUnhandledExceptionMode(CatchException) — WinForms больше не показывает ThreadExceptionDialog;
- обработчик Application.ThreadException — ловит исключение WinForms-потока;
- обработчик DispatcherUnhandledException с e.Handled = true — ловит WPF-исключение, приложение не падает.
Общий метод LogUiThreadException пишет первичное исключение в лог-файл (ServerMaster.Log) и отправляет на краш-сервер — без MessageBox, чтобы не создавать новый вложенный модальный цикл.

Обратная совместимость: изменение аддитивное (новые подписки на события при старте). Публичные API, файлы конфигурации и форматы данных не менялись. Ломающего нет. Поведенческое отличие: UI-исключение больше не роняет приложение, а логируется.

Как тестировал: сборка dotnet build чистая (0 ошибок). Тест-стенд Artifacts/UiThreadExceptionTestStand/ (WPF + hosted WinForms) воспроизводит оба пути — WinForms-исключение (через WinForms-таймер) и WPF-исключение (через DispatcherTimer) — и проверяет, что первичное исключение перехвачено и залогировано. Прогон: exit 0, обе метки в логе.

Нюансы: раз приложение не падает, пользователь не увидит окна «приложение упало» — ошибка уйдёт в лог тихо. Репорты не отключены: каждое перехваченное UI-исключение по-прежнему отправляется на краш-сервер, но теперь с корректным первичным исключением вместо вторичного throw.

Одобрили:
- Фиксер — подтвердил по краш-отчёту, статическому анализу кода и тест-стенду
- остальные: нет
